### PR TITLE
Added code to infer the tenantId from a parameter called `tenantId` if present.

### DIFF
--- a/Solutions/Menes.Abstractions/Menes/IOpenApiContext.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiContext.cs
@@ -24,6 +24,6 @@ namespace Menes
         /// <summary>
         /// Gets or sets additional context for the request.
         /// </summary>
-        dynamic AdditionalContext { get; set;  }
+        object AdditionalContext { get; set;  }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiContextBuilder.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiContextBuilder.cs
@@ -19,6 +19,6 @@ namespace Menes
         /// <param name="parameters">A dynamic parameters object for the context builder.</param>
         /// <returns>The context for the request.</returns>
         /// <remarks>The parameters are defined by the particular context builder, and may include e.g. tenancy.</remarks>
-        Task<IOpenApiContext> BuildAsync(TRequest request, dynamic parameters);
+        Task<IOpenApiContext> BuildAsync(TRequest request, object parameters);
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiContextBuilderComponent.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiContextBuilderComponent.cs
@@ -19,6 +19,6 @@ namespace Menes
         /// <param name="request">The incoming request.</param>
         /// <param name="parameters">A dyamically built parameters object passed to the builder.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task BuildAsync(IOpenApiContext context, TRequest request, dynamic parameters);
+        Task BuildAsync(IOpenApiContext context, TRequest request, object parameters);
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiHost.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiHost.cs
@@ -28,6 +28,6 @@ namespace Menes
         /// <param name="request">The underlying request body.</param>
         /// <param name="parameters">The dynamically created parameters for the request.</param>
         /// <returns>A <see cref="Task{T}"/> which when complete, provides the response.</returns>
-        Task<TResponse> HandleRequestAsync(string path, string method, TRequest request, dynamic parameters);
+        Task<TResponse> HandleRequestAsync(string path, string method, TRequest request, object parameters);
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiContextBuilder.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiContextBuilder.cs
@@ -27,7 +27,7 @@ namespace Menes.Internal
         }
 
         /// <inheritdoc/>
-        public async Task<IOpenApiContext> BuildAsync(TRequest request, dynamic parameters)
+        public async Task<IOpenApiContext> BuildAsync(TRequest request, object parameters)
         {
             var context = new TContextType
             {

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/HttpRequestExtensions.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/HttpRequestExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="httpRequest">The request to handle.</param>
         /// <param name="parameters">Any dynamically constructed parameters sent to the request.</param>
         /// <returns>The result of the request.</returns>
-        public static Task<IActionResult> HandleRequestAsync(this IOpenApiHost<HttpRequest, IActionResult> host, HttpRequest httpRequest, dynamic parameters)
+        public static Task<IActionResult> HandleRequestAsync(this IOpenApiHost<HttpRequest, IActionResult> host, HttpRequest httpRequest, object parameters)
         {
             return host.HandleRequestAsync(httpRequest.Path, httpRequest.Method, httpRequest, parameters);
         }

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/SimpleOpenApiContext.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/SimpleOpenApiContext.cs
@@ -18,6 +18,6 @@ namespace Menes
         public string CurrentTenantId { get; set;  }
 
         /// <inheritdoc/>
-        public dynamic AdditionalContext { get; set; }
+        public object AdditionalContext { get; set; }
     }
 }

--- a/Solutions/Menes.Hosting/Menes/Internal/OpenApiOperationInvoker.cs
+++ b/Solutions/Menes.Hosting/Menes/Internal/OpenApiOperationInvoker.cs
@@ -79,6 +79,13 @@ namespace Menes.Internal
             try
             {
                 IDictionary<string, object> namedParameters = await this.BuildRequestParametersAsync(request, operationPathTemplate).ConfigureAwait(false);
+
+                // Try to find the tenantID in the parameters, but before we check the access policies.
+                if (namedParameters.TryGetValue("tenantId", out object tenantIdObject) && tenantIdObject is string tenantId)
+                {
+                    context.CurrentTenantId = tenantId;
+                }
+
                 await this.CheckAccessPoliciesAsync(context, path, method, operationPathTemplate.Operation.OperationId).ConfigureAwait(false);
                 object result = openApiServiceOperation.Execute(context, namedParameters);
 

--- a/Solutions/Menes.Hosting/Menes/OpenApiHost.cs
+++ b/Solutions/Menes.Hosting/Menes/OpenApiHost.cs
@@ -38,7 +38,7 @@ namespace Menes
         }
 
         /// <inheritdoc/>
-        public async Task<TResponse> HandleRequestAsync(string path, string method, TRequest request, dynamic parameters)
+        public async Task<TResponse> HandleRequestAsync(string path, string method, TRequest request, object parameters)
         {
             IOpenApiContext context = await this.BuildContextAsync(request, parameters).ConfigureAwait(false);
 
@@ -68,7 +68,7 @@ namespace Menes
         /// <param name="request">The request from which to build the OpenAPI context.</param>
         /// <param name="parameters">The dynamically built parameters from which to build the context.</param>
         /// <returns>A <see cref="Task{TResult}"/> which, when complete, provides the <see cref="IOpenApiContext"/>.</returns>
-        private async Task<IOpenApiContext> BuildContextAsync(TRequest request, dynamic parameters)
+        private async Task<IOpenApiContext> BuildContextAsync(TRequest request, object parameters)
         {
             return await this.contextBuilder.BuildAsync(request, parameters).ConfigureAwait(false);
         }


### PR DESCRIPTION
This is an interim fix for the work to pull out Tenancy from the Menes pipeline in general.

Really, we would like to build the context *after* we build the parameters, so that we can pass the parameters to the context build. I have opened Issue #4  for this. 