### PR TITLE
Fix analyzer messages and demo ListPets

### DIFF
--- a/Solutions/.editorconfig
+++ b/Solutions/.editorconfig
@@ -68,3 +68,6 @@ dotnet_style_qualification_for_field = true:suggestion
 dotnet_style_qualification_for_method = true:suggestion
 dotnet_style_qualification_for_property = true:suggestion
 dotnet_style_qualification_for_event = true:suggestion
+
+# Style - using
+csharp_using_directive_placement = inside_namespace:warning

--- a/Solutions/Menes.Abstractions/Menes/Hal/HalDocument.cs
+++ b/Solutions/Menes.Abstractions/Menes/Hal/HalDocument.cs
@@ -6,9 +6,7 @@ namespace Menes.Hal
 {
     using System.Collections.Generic;
     using System.Linq;
-    using Corvus.ContentHandling;
     using Corvus.Extensions.Json;
-    using Menes.Internal;
     using Menes.Links;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -132,18 +130,16 @@ namespace Menes.Hal
                 return true;
             }
 
-            using (JsonReader reader = this.Properties.CreateReader())
+            using JsonReader reader = this.Properties.CreateReader();
+            try
             {
-                try
-                {
-                    result = JsonSerializer.Create(this.SerializerSettings).Deserialize<T>(reader);
-                    return true;
-                }
-                catch (JsonSerializationException)
-                {
-                    result = default;
-                    return false;
-                }
+                result = JsonSerializer.Create(this.SerializerSettings).Deserialize<T>(reader);
+                return true;
+            }
+            catch (JsonSerializationException)
+            {
+                result = default;
+                return false;
             }
         }
 

--- a/Solutions/Menes.Abstractions/Menes/Hal/Internal/HalDocumentFactory.cs
+++ b/Solutions/Menes.Abstractions/Menes/Hal/Internal/HalDocumentFactory.cs
@@ -5,7 +5,6 @@
 namespace Menes.Hal.Internal
 {
     using System;
-    using Menes.Links;
     using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentJsonConverter.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentJsonConverter.cs
@@ -46,17 +46,13 @@ namespace Menes.Internal
         {
             var document = (OpenApiDocument)value;
 
-            using (var stream = new MemoryStream())
-            {
-                document.SerializeAsJson(stream, OpenApiSpecVersion.OpenApi2_0);
-                stream.Seek(0, SeekOrigin.Begin);
+            using var stream = new MemoryStream();
+            document.SerializeAsJson(stream, OpenApiSpecVersion.OpenApi2_0);
+            stream.Seek(0, SeekOrigin.Begin);
 
-                using (var reader = new StreamReader(stream))
-                {
-                    string json = reader.ReadToEnd();
-                    writer.WriteRaw(json);
-                }
-            }
+            using var reader = new StreamReader(stream);
+            string json = reader.ReadToEnd();
+            writer.WriteRaw(json);
         }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiExtensions.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiExtensions.cs
@@ -20,27 +20,19 @@ namespace Menes.Internal
         /// <exception cref="ArgumentException">Thrown if the method string is unsupported.</exception>
         public static OperationType ToOperationType(this string httpMethod)
         {
-            switch (httpMethod.ToLowerInvariant())
+            return httpMethod.ToLowerInvariant() switch
             {
-                case "delete":
-                    return OperationType.Delete;
-                case "get":
-                    return OperationType.Get;
-                case "head":
-                    return OperationType.Head;
-                case "options":
-                    return OperationType.Options;
-                case "patch":
-                    return OperationType.Patch;
-                case "post":
-                    return OperationType.Post;
-                case "put":
-                    return OperationType.Put;
-                case "trace":
-                    return OperationType.Trace;
-                default:
-                    throw new ArgumentException("Unsupported Http Method", nameof(httpMethod));
-            }
+                "delete"  => OperationType.Delete,
+                "get"     => OperationType.Get,
+                "head"    => OperationType.Head,
+                "options" => OperationType.Options,
+                "patch"   => OperationType.Patch,
+                "post"    => OperationType.Post,
+                "put"     => OperationType.Put,
+                "trace"   => OperationType.Trace,
+
+                _ => throw new ArgumentException("Unsupported Http Method", nameof(httpMethod)),
+            };
         }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/OpenApiResultExtensions.cs
+++ b/Solutions/Menes.Abstractions/Menes/OpenApiResultExtensions.cs
@@ -31,7 +31,7 @@ namespace Menes
         {
             if (values?.Length > 0)
             {
-                openApiResult.AuditData = openApiResult.AuditData ?? new Dictionary<string, object>();
+                openApiResult.AuditData ??= new Dictionary<string, object>();
                 openApiResult.AuditData.AddRange(values.Select(x => new KeyValuePair<string, object>(x.Item1, x.Item2)));
             }
         }

--- a/Solutions/Menes.Abstractions/Menes/OpenApiServiceDefinitions.cs
+++ b/Solutions/Menes.Abstractions/Menes/OpenApiServiceDefinitions.cs
@@ -31,18 +31,16 @@ namespace Menes
                     $"Type {typeof(T).FullName} does not have the EmbeddedOpenApiDefinitionAttribute attribute", "T");
             }
 
-            using (Stream stream = typeof(T).Assembly.GetManifestResourceStream(attribute.ResourceName))
+            OpenApiDocument openApiDocument = ReadOpenApiServiceFromEmbeddedDefinitionWithDiagnostics(
+                typeof(T).Assembly, attribute.ResourceName, out OpenApiDiagnostic diagnostics);
+
+            if (diagnostics.Errors.Count > 0)
             {
-                OpenApiDocument openApiDocument = new OpenApiStreamReader().Read(stream, out OpenApiDiagnostic diagnostics);
-
-                if (diagnostics.Errors.Count > 0)
-                {
-                    throw new OpenApiServiceMismatchException($"Errors reading the YAML file for service {typeof(T).FullName} at resource name attribute.ResourceName")
-                        .AddProblemDetailsExtension("OpenApiErrors", diagnostics.Errors);
-                }
-
-                return openApiDocument;
+                throw new OpenApiServiceMismatchException($"Errors reading the YAML file for service {typeof(T).FullName} at resource name attribute.ResourceName")
+                    .AddProblemDetailsExtension("OpenApiErrors", diagnostics.Errors);
             }
+
+            return openApiDocument;
         }
 
         /// <summary>
@@ -55,18 +53,32 @@ namespace Menes
             Assembly assembly,
             string resourceName)
         {
-            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+            OpenApiDocument openApiDocument = ReadOpenApiServiceFromEmbeddedDefinitionWithDiagnostics(
+                assembly, resourceName, out OpenApiDiagnostic diagnostics);
+
+            if (diagnostics.Errors.Count > 0)
             {
-                OpenApiDocument openApiDocument = new OpenApiStreamReader().Read(stream, out OpenApiDiagnostic diagnostics);
-
-                if (diagnostics.Errors.Count > 0)
-                {
-                    throw new OpenApiServiceMismatchException($"Errors reading the YAML file at resource name attribute.ResourceName")
-                        .AddProblemDetailsExtension("OpenApiErrors", diagnostics.Errors);
-                }
-
-                return openApiDocument;
+                throw new OpenApiServiceMismatchException($"Errors reading the YAML file at resource name attribute.ResourceName")
+                    .AddProblemDetailsExtension("OpenApiErrors", diagnostics.Errors);
             }
+
+            return openApiDocument;
+        }
+
+        /// <summary>
+        /// Gets an Open API YAML file stored as an embedded resource, and returns parsing diagnostics.
+        /// </summary>
+        /// <param name="assembly">The assembly in which the resource is stored.</param>
+        /// <param name="resourceName">The name of the embedded resource.</param>
+        /// <param name="diagnostics">Diagnostics will be returned through this parameter.</param>
+        /// <returns>The parsed document.</returns>
+        public static OpenApiDocument ReadOpenApiServiceFromEmbeddedDefinitionWithDiagnostics(
+            Assembly assembly,
+            string resourceName,
+            out OpenApiDiagnostic diagnostics)
+        {
+            using Stream stream = assembly.GetManifestResourceStream(resourceName);
+            return new OpenApiStreamReader().Read(stream, out diagnostics);
         }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Validation/OpenApiSchemaValidator.cs
+++ b/Solutions/Menes.Abstractions/Menes/Validation/OpenApiSchemaValidator.cs
@@ -273,13 +273,11 @@ namespace Menes.Validation
 
         private string WriteToString(IOpenApiAny v)
         {
-            using (var textWriter = new StringWriter())
-            {
-                var openApiWriter = new OpenApiJsonWriter(textWriter);
-                openApiWriter.WriteAny(v);
-                textWriter.Flush();
-                return textWriter.ToString().Trim('"');
-            }
+            using var textWriter = new StringWriter();
+            var openApiWriter = new OpenApiJsonWriter(textWriter);
+            openApiWriter.WriteAny(v);
+            textWriter.Flush();
+            return textWriter.ToString().Trim('"');
         }
 
         private void ValidateString(JToken token, OpenApiSchema schema, JsonObjectType type, string propertyName, string propertyPath, List<ValidationError> errors)

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/HttpRequestParameterBuilder.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/HttpRequestParameterBuilder.cs
@@ -322,11 +322,13 @@ namespace Menes.Internal
 
         private async Task<object> ConvertBodyAsync(OpenApiSchema schema, Stream body)
         {
+            string value;
             using (var reader = new StreamReader(body))
             {
-                string value = await reader.ReadToEndAsync().ConfigureAwait(false);
-                return this.ConvertValue(schema, value);
+                value = await reader.ReadToEndAsync().ConfigureAwait(false);
             }
+
+            return this.ConvertValue(schema, value);
         }
 
         private bool TryGetParameterFromHeader(IHeaderDictionary headers, OpenApiParameter parameter, out object result)

--- a/Solutions/Menes.Hosting/Menes/Internal/OpenApiOperationInvoker.cs
+++ b/Solutions/Menes.Hosting/Menes/Internal/OpenApiOperationInvoker.cs
@@ -181,26 +181,14 @@ namespace Menes.Internal
 
             if (result.ResultType == AccessControlPolicyResultType.NotAuthenticated)
             {
-                Exception x;
-                switch (this.configuration.AccessPolicyUnauthenticatedResponse)
+                Exception x = this.configuration.AccessPolicyUnauthenticatedResponse switch
                 {
-                    case ResponseWhenUnauthenticated.Unauthorized:
-                        x = new OpenApiUnauthorizedException("Unauthorized");
-                        break;
+                    ResponseWhenUnauthenticated.Unauthorized => new OpenApiUnauthorizedException("Unauthorized"),
+                    ResponseWhenUnauthenticated.Forbidden    => OpenApiForbiddenException.WithoutProblemDetails("Forbidden"),
+                    ResponseWhenUnauthenticated.ServerError  => new OpenApiServiceMismatchException("Unauthenticated requests should not be reaching this service"),
 
-                    case ResponseWhenUnauthenticated.Forbidden:
-                        x = OpenApiForbiddenException.WithoutProblemDetails("Forbidden");
-                        break;
-
-                    case ResponseWhenUnauthenticated.ServerError:
-                        x = new OpenApiServiceMismatchException("Unauthenticated requests should not be reaching this service");
-                        break;
-
-                    default:
-                        x = new OpenApiServiceMismatchException($"Unknown AccessPolicyUnauthenticatedResponse: {this.configuration.AccessPolicyUnauthenticatedResponse}");
-                        break;
-                }
-
+                    _ => new OpenApiServiceMismatchException($"Unknown AccessPolicyUnauthenticatedResponse: {this.configuration.AccessPolicyUnauthenticatedResponse}"),
+                };
                 if (!string.IsNullOrWhiteSpace(result.Explanation))
                 {
                     x.AddProblemDetailsExplanation(result.Explanation);

--- a/Solutions/Menes.Hosting/Menes/OpenApiHost.cs
+++ b/Solutions/Menes.Hosting/Menes/OpenApiHost.cs
@@ -14,7 +14,6 @@ namespace Menes
     /// <typeparam name="TResponse">The type of the repsonse.</typeparam>
     public class OpenApiHost<TRequest, TResponse> : IOpenApiHost<TRequest, TResponse>
     {
-        private readonly IOpenApiServiceOperationLocator operationLocator;
         private readonly IPathMatcher matcher;
         private readonly IOpenApiContextBuilder<TRequest> contextBuilder;
         private readonly IOpenApiOperationInvoker<TRequest, TResponse> operationInvoker;
@@ -23,14 +22,12 @@ namespace Menes
         /// <summary>
         /// Creates an instance of the <see cref="OpenApiHost{TRequest, TResponse}"/>.
         /// </summary>
-        /// <param name="operationLocator">The operation locator.</param>
         /// <param name="matcher">The path matcher.</param>
         /// <param name="contextBuilder">The OpenAPI context builder.</param>
         /// <param name="operationInvoker">The OpenAPI operation invoker.</param>
         /// <param name="resultBuilder">The OpenAPI result builder.</param>
-        public OpenApiHost(IOpenApiServiceOperationLocator operationLocator, IPathMatcher matcher, IOpenApiContextBuilder<TRequest> contextBuilder, IOpenApiOperationInvoker<TRequest, TResponse> operationInvoker, IOpenApiResultBuilder<TResponse> resultBuilder)
+        public OpenApiHost(IPathMatcher matcher, IOpenApiContextBuilder<TRequest> contextBuilder, IOpenApiOperationInvoker<TRequest, TResponse> operationInvoker, IOpenApiResultBuilder<TResponse> resultBuilder)
         {
-            this.operationLocator = operationLocator;
             this.matcher = matcher;
             this.contextBuilder = contextBuilder;
             this.operationInvoker = operationInvoker;

--- a/Solutions/Menes.Hosting/Microsoft/Extensions/DependencyInjection/OpenApiHostingServiceCollectionExtensions.cs
+++ b/Solutions/Menes.Hosting/Microsoft/Extensions/DependencyInjection/OpenApiHostingServiceCollectionExtensions.cs
@@ -115,7 +115,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton((Func<IServiceProvider, IOpenApiHost<TRequest, TResponse>>)(serviceProvider =>
             {
                 var result = new OpenApiHost<TRequest, TResponse>(
-                        serviceProvider.GetRequiredService<IOpenApiServiceOperationLocator>(),
                         serviceProvider.GetRequiredService<IPathMatcher>(),
                         serviceProvider.GetRequiredService<IOpenApiContextBuilder<TRequest>>(),
                         serviceProvider.GetRequiredService<IOpenApiOperationInvoker<TRequest, TResponse>>(),

--- a/Solutions/Menes.PetStore.Hosting/Menes/PetStore/Hosting/Startup.cs
+++ b/Solutions/Menes.PetStore.Hosting/Menes/PetStore/Hosting/Startup.cs
@@ -26,6 +26,7 @@ namespace Menes.PetStore.Hosting
             IServiceCollection services = builder.Services;
 
             services.AddLogging();
+            services.AddHttpClient();
 
             services.AddHalDocumentMapper<PetResource, PetResourceMapper>();
             services.AddHalDocumentMapper<PetListResource, PetListResourceMapper>();
@@ -43,12 +44,14 @@ namespace Menes.PetStore.Hosting
 
         private static void LoadDocuments(IOpenApiHostConfiguration hostConfig)
         {
+            OpenApiDocument openApiDocument;
             using (FileStream stream = File.OpenRead(".\\yaml\\petstore.yaml"))
             {
-                OpenApiDocument openApiDocument = new OpenApiStreamReader().Read(stream, out OpenApiDiagnostic diagnostics);
-                hostConfig.Documents.Add(openApiDocument);
-                hostConfig.Documents.AddSwaggerEndpoint();
+                openApiDocument = new OpenApiStreamReader().Read(stream, out _);
             }
+
+            hostConfig.Documents.Add(openApiDocument);
+            hostConfig.Documents.AddSwaggerEndpoint();
         }
     }
 }

--- a/Solutions/Menes.PetStore/Menes.PetStore.csproj
+++ b/Solutions/Menes.PetStore/Menes.PetStore.csproj
@@ -11,6 +11,10 @@
   <Import Project="..\Common.NetStandard_2_0.proj" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Menes.Abstractions\Menes.Abstractions.csproj" />
   </ItemGroup>
 

--- a/Solutions/Menes.PetStore/Menes/PetStore/Responses/Mappers/PetListResourceMapper.cs
+++ b/Solutions/Menes.PetStore/Menes/PetStore/Responses/Mappers/PetListResourceMapper.cs
@@ -45,12 +45,12 @@ namespace Menes.PetStore.Responses.Mappers
             HalDocument response = this.halDocumentFactory.CreateHalDocumentFrom(pets);
             response.AddEmbeddedResources(PetsRelation, pets.Pets.Select(this.petResourceMapper.Map));
 
-            response.ResolveAndAdd(this.linkResolver, response, "self", ("limit", pets.PageSize), ("continuationToken", pets.CurrentContinuationToken));
-            response.ResolveAndAdd(this.linkResolver, response, "create");
+            response.ResolveAndAdd(this.linkResolver, pets, "self", ("limit", pets.PageSize), ("continuationToken", pets.CurrentContinuationToken));
+            response.ResolveAndAdd(this.linkResolver, pets, "create");
 
             if (!string.IsNullOrEmpty(pets.NextContinuationToken))
             {
-                response.ResolveAndAdd(this.linkResolver, response, "next", ("limit", pets.PageSize), ("continuationToken", pets.NextContinuationToken));
+                response.ResolveAndAdd(this.linkResolver, pets, "next", ("limit", pets.PageSize), ("continuationToken", pets.NextContinuationToken));
             }
 
             return response;

--- a/Solutions/Menes.Specs/Bindings/MenesContainerBindings.cs
+++ b/Solutions/Menes.Specs/Bindings/MenesContainerBindings.cs
@@ -4,12 +4,8 @@
 
 namespace Marain.Claims.SpecFlow.Bindings
 {
-    using System.Collections.Generic;
     using Corvus.SpecFlow.Extensions;
     using Menes;
-    using Menes.Hal;
-    using Menes.Hal.Internal;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using TechTalk.SpecFlow;
 

--- a/Solutions/Menes.Specs/Steps/OpenApiWebLinkResolverSteps.cs
+++ b/Solutions/Menes.Specs/Steps/OpenApiWebLinkResolverSteps.cs
@@ -9,7 +9,6 @@ namespace Menes.Specs.Steps
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Reflection;
     using Menes.Internal;
@@ -34,17 +33,15 @@ namespace Menes.Specs.Steps
         [Given("I have initialised the OpenApiDocument provider from test YAML file '(.*)'")]
         public void GivenIHaveInitialisedTheOpenApiDocumentProviderFromTestYAMLFile(string embeddedResourceName)
         {
-            using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(embeddedResourceName))
-            {
-                OpenApiDocument document = new OpenApiStreamReader().Read(stream, out OpenApiDiagnostic diagnostic);
+            OpenApiDocument document = OpenApiServiceDefinitions.ReadOpenApiServiceFromEmbeddedDefinitionWithDiagnostics(
+                Assembly.GetExecutingAssembly(), embeddedResourceName, out OpenApiDiagnostic diagnostic);
 
-                Assert.IsEmpty(diagnostic.Errors);
+            Assert.IsEmpty(diagnostic.Errors);
 
-                var documentProvider = new OpenApiDocumentProvider(new LoggerFactory().CreateLogger<OpenApiDocumentProvider>());
-                documentProvider.Add(document);
+            var documentProvider = new OpenApiDocumentProvider(new LoggerFactory().CreateLogger<OpenApiDocumentProvider>());
+            documentProvider.Add(document);
 
-                this.scenarioContext.Set<IOpenApiDocumentProvider>(documentProvider);
-            }
+            this.scenarioContext.Set<IOpenApiDocumentProvider>(documentProvider);
         }
 
         [Given("I have mapped link relations by type")]

--- a/Solutions/Menes.Specs/Steps/TestClasses/Pet.cs
+++ b/Solutions/Menes.Specs/Steps/TestClasses/Pet.cs
@@ -4,8 +4,6 @@
 
 namespace Menes.Specs.Steps.TestClasses
 {
-    using System;
-
     /// <summary>
     /// Pet DTO.
     /// </summary>

--- a/Solutions/Menes.sln
+++ b/Solutions/Menes.sln
@@ -15,7 +15,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Demo", "Demo", "{9F5741F1-1
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Menes.PetStore.Hosting", "Menes.PetStore.Hosting\Menes.PetStore.Hosting.csproj", "{C5D7A4FA-88FB-4E7F-BB49-2B1F19323DD0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Menes.Specs", "Menes.Specs\Menes.Specs.csproj", "{D4255494-ACA0-4F19-8425-AE5B134A9C7F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Menes.Specs", "Menes.Specs\Menes.Specs.csproj", "{D4255494-ACA0-4F19-8425-AE5B134A9C7F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7D2D4E50-99AF-4F25-A28C-A8A391641070}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		Common.GitHub.proj = Common.GitHub.proj
+		Common.NetStandard_2_0.proj = Common.NetStandard_2_0.proj
+		Common.NuGet.proj = Common.NuGet.proj
+		Directory.build.props = Directory.build.props
+		Directory.build.targets = Directory.build.targets
+		stylecop.json = stylecop.json
+		StyleCop.ruleset = StyleCop.ruleset
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Solutions/StyleCop.ruleset
+++ b/Solutions/StyleCop.ruleset
@@ -4,5 +4,9 @@
     <!-- StyleCop's insistence that constructors' summaries must always start with exactly
          the same boilerplate text is not deeply helpful. -->
     <Rule Id="SA1642" Action="None" />
+    <!-- SA1025 makes it impossible to write decent-looking switch expressions because it
+         doesn't allow multiple whitespace characters in a row. And there seems to be no way
+         to disable it just inside switch expressions. So we reluctantly live without it. -->
+    <Rule Id="SA1025" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Ensures that the Error List in Visual Studio is completely clear when you load the project. Before this we got numerous entries under Messages.

This PR also ended up fixing the Pet Store demo's List Pets endpoint—one of the changes I made to resolve a message about `using` style ended up affecting that endpoint, which meant I needed to test the endpoint. But it turned out it wasn't working before. So I had to fix it as part of this work.

In many cases C#'s suggestion that we use the new `using` declaration syntax revealed slight problems in the code. For example, we had duplicated the code for loading an OpenAPI spec from a resource in a few places. I've refactored that (since I had to modify all the offending code in any place to fix the diagnostic messages.

Another of those suggestions was around a use of `WebClient`. This was problematic in a couple of ways. First, we're generally discouraged from using `WebClient` these days. And second, disposal of your HTTP client (whether its literally an `HttpClient` or not) is bad practice. And although Pet Store is only a demo, it shouldn't showcase bad practice. So I fixed this by introducing the use of `IHttpClientFactory`. That's arguably a somewhat heavyweight way to fix a diagnostic message about a `using`, but the diagnostic found a problem, and this is the right fix for that problem.