### PR TITLE
Enable C# 8.0 nullable references

### DIFF
--- a/Solutions/Menes.Abstractions/Menes.Abstractions.csproj
+++ b/Solutions/Menes.Abstractions/Menes.Abstractions.csproj
@@ -1,10 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageDescription>Menes is a framework for hosting Web APIs with OpenAPI-based service definitions. This library defines the common abstractions used throughout Menes.</PackageDescription>
     <WarningsAsErrors />
+    
+    <!--
+      RCS1194 - we don't want the standard ctor patterns, as they clash with nullable references
+    -->
+    <NoWarn>RCS1194</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +26,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.1.4" />
+    <PackageReference Include="Nullable" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Interactive" Version="3.2.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />

--- a/Solutions/Menes.Abstractions/Menes/AccessCheckOperationDescriptor.cs
+++ b/Solutions/Menes.Abstractions/Menes/AccessCheckOperationDescriptor.cs
@@ -14,7 +14,7 @@ namespace Menes
     /// involved in that process.
     /// </summary>
     [DebuggerDisplay("{OperationId} - {Method} {Path}")]
-    public class AccessCheckOperationDescriptor : IEquatable<AccessCheckOperationDescriptor>
+    public class AccessCheckOperationDescriptor : IEquatable<AccessCheckOperationDescriptor?>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AccessCheckOperationDescriptor"/> class.
@@ -50,7 +50,7 @@ namespace Menes
         /// <param name="left">The left hand side of the equality check.</param>
         /// <param name="right">The right hand side of the equality check.</param>
         /// <returns>True if the values are equal, false otherwise.</returns>
-        public static bool operator ==(AccessCheckOperationDescriptor left, AccessCheckOperationDescriptor right)
+        public static bool operator ==(AccessCheckOperationDescriptor? left, AccessCheckOperationDescriptor? right)
         {
             if (object.ReferenceEquals(left, right))
             {
@@ -72,13 +72,13 @@ namespace Menes
         /// <param name="left">The left hand side of the equality check.</param>
         /// <param name="right">The right hand side of the equality check.</param>
         /// <returns>False if the values are equal, true otherwise.</returns>
-        public static bool operator !=(AccessCheckOperationDescriptor left, AccessCheckOperationDescriptor right)
+        public static bool operator !=(AccessCheckOperationDescriptor? left, AccessCheckOperationDescriptor? right)
         {
             return !(left == right);
         }
 
         /// <inheritdoc/>
-        public bool Equals(AccessCheckOperationDescriptor other)
+        public bool Equals(AccessCheckOperationDescriptor? other)
         {
             if (other == null)
             {

--- a/Solutions/Menes.Abstractions/Menes/AccessControlPolicyResult.cs
+++ b/Solutions/Menes.Abstractions/Menes/AccessControlPolicyResult.cs
@@ -25,7 +25,7 @@ namespace Menes
         /// </param>
         public AccessControlPolicyResult(
             AccessControlPolicyResultType resultType,
-            string explanation = null)
+            string? explanation = null)
         {
             if (resultType == AccessControlPolicyResultType.Allowed && !string.IsNullOrEmpty(explanation))
             {
@@ -47,7 +47,7 @@ namespace Menes
         /// Gets an explanation of why the operation is blocked. May be returned in a Problem
         /// Details response body.
         /// </summary>
-        public string Explanation { get; }
+        public string? Explanation { get; }
 
         /// <summary>
         /// Gets a value describing whether the access policy was evaluated, and if so what the

--- a/Solutions/Menes.Abstractions/Menes/Auditing/AuditLog.cs
+++ b/Solutions/Menes.Abstractions/Menes/Auditing/AuditLog.cs
@@ -18,6 +18,15 @@ namespace Menes.Auditing
         public const string RegisteredContentType = "application/vnd.menes.auditing.audit-log";
 
         /// <summary>
+        /// Creates an <see cref="AuditLog"/>.
+        /// </summary>
+        /// <param name="operation">The <see cref="Operation"/>.</param>
+        public AuditLog(string operation)
+        {
+            this.Operation = operation;
+        }
+
+        /// <summary>
         /// Gets or sets the date and time that the audit log was created.
         /// </summary>
         public DateTimeOffset CreatedDateTimeUtc { get; set; } = DateTimeOffset.UtcNow;
@@ -30,12 +39,12 @@ namespace Menes.Auditing
         /// <summary>
         /// Gets or sets the Id of the tenant for the operation.
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Gets or sets the Id of the user who attempted the audited activity.
         /// </summary>
-        public string UserId { get; set; }
+        public string? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the operation that is being audited.
@@ -45,7 +54,7 @@ namespace Menes.Auditing
         /// <summary>
         /// Gets or sets the result of the action. This should be an HTTP status code.
         /// </summary>
-        public int Result { get; set; }
+        public int? Result { get; set; }
 
         /// <summary>
         /// Gets or sets a list of additional data for the audit log.

--- a/Solutions/Menes.Abstractions/Menes/Auditing/Internal/AuditContext.cs
+++ b/Solutions/Menes.Abstractions/Menes/Auditing/Internal/AuditContext.cs
@@ -58,9 +58,8 @@ namespace Menes.Auditing
         {
             if (this.IsAuditingEnabled)
             {
-                var log = new AuditLog
+                var log = new AuditLog(operation.OperationId)
                 {
-                    Operation = operation.OperationId,
                     Result = statusCode,
                     UserId = context.CurrentPrincipal?.Identity?.Name,
                 };
@@ -74,8 +73,11 @@ namespace Menes.Auditing
         {
             if (this.IsAuditingEnabled)
             {
-                AuditLog log = this.BuildAuditLog(context, result, operation);
-                await this.auditSinks.LogAsync(context, log).ConfigureAwait(false);
+                AuditLog? log = this.BuildAuditLog(context, result, operation);
+                if (log != null)
+                {
+                    await this.auditSinks.LogAsync(context, log).ConfigureAwait(false);
+                }
             }
         }
 
@@ -86,7 +88,7 @@ namespace Menes.Auditing
         /// <param name="result">The result of the operation.</param>
         /// <param name="operation">The OpenAPI operation.</param>
         /// <returns>The audit log entry for the result, operation, and context.</returns>
-        private AuditLog BuildAuditLog(IOpenApiContext context, object result, OpenApiOperation operation)
+        private AuditLog? BuildAuditLog(IOpenApiContext context, object result, OpenApiOperation operation)
         {
             if (this.logger.IsEnabled(LogLevel.Debug))
             {

--- a/Solutions/Menes.Abstractions/Menes/Auditing/Internal/OpenApiResultAuditLogBuilder.cs
+++ b/Solutions/Menes.Abstractions/Menes/Auditing/Internal/OpenApiResultAuditLogBuilder.cs
@@ -22,15 +22,19 @@ namespace Menes.Auditing.Internal
         {
             var openApiResult = result as OpenApiResult;
 
-            return new AuditLog
+            var auditLog = new AuditLog(operation.OperationId)
             {
                 CreatedDateTimeUtc = DateTimeOffset.UtcNow,
-                Operation = operation.OperationId,
-                Result = openApiResult.StatusCode,
+                Result = openApiResult?.StatusCode,
                 TenantId = context.CurrentTenantId,
                 UserId = context.CurrentPrincipal?.Identity?.Name,
-                Properties = openApiResult.AuditData,
             };
+            if (openApiResult != null)
+            {
+                auditLog.Properties = openApiResult.AuditData;
+            }
+
+            return auditLog;
         }
 
         /// <inheritdoc />

--- a/Solutions/Menes.Abstractions/Menes/Auditing/Internal/PocoAuditLogBuilder.cs
+++ b/Solutions/Menes.Abstractions/Menes/Auditing/Internal/PocoAuditLogBuilder.cs
@@ -19,10 +19,9 @@ namespace Menes.Auditing.Internal
         /// <inheritdoc />
         public AuditLog BuildAuditLog(IOpenApiContext context, object result, OpenApiOperation operation)
         {
-            return new AuditLog
+            return new AuditLog(operation.OperationId)
             {
                 CreatedDateTimeUtc = DateTimeOffset.UtcNow,
-                Operation = operation.OperationId,
                 Result = 200,
                 TenantId = context.CurrentTenantId,
                 UserId = context.CurrentPrincipal?.Identity?.Name,

--- a/Solutions/Menes.Abstractions/Menes/Converters/ObjectConverter.cs
+++ b/Solutions/Menes.Abstractions/Menes/Converters/ObjectConverter.cs
@@ -45,7 +45,7 @@ namespace Menes.Converters
             this.validator.ValidateAndThrow(content, schema);
 
             // Use the discriminator to look up the type, if it is available
-            string discriminator = schema.Discriminator?.PropertyName;
+            string? discriminator = schema.Discriminator?.PropertyName;
 
             string type;
             if (!string.IsNullOrEmpty(discriminator))

--- a/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiAccessControlPolicyEvaluationFailedException.cs
+++ b/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiAccessControlPolicyEvaluationFailedException.cs
@@ -13,43 +13,8 @@ namespace Menes.Exceptions
     /// to evaluate due for an unexpected reason - e.g. a configuration error, third party
     /// service unavailable or similar.
     /// </summary>
-    [Serializable]
     public class OpenApiAccessControlPolicyEvaluationFailedException : Exception
     {
-        /// <summary>
-        /// Creates a new instance of <see cref="OpenApiAccessControlPolicyEvaluationFailedException"/>.
-        /// </summary>
-        /// <remarks>
-        /// Avoid using this constructor; prefer a constructor that accepts details of the problem.
-        /// </remarks>
-        public OpenApiAccessControlPolicyEvaluationFailedException()
-        {
-            this.AddProblemDetails();
-        }
-
-        /// <summary>
-        /// Creates a new instance of <see cref="OpenApiAccessControlPolicyEvaluationFailedException"/> with
-        /// the specified error message.
-        /// </summary>
-        /// <param name="message">The exception message.</param>
-        public OpenApiAccessControlPolicyEvaluationFailedException(string message)
-            : base(message)
-        {
-            this.AddProblemDetails();
-        }
-
-        /// <summary>
-        /// Creates a new instance of <see cref="OpenApiAccessControlPolicyEvaluationFailedException"/> with
-        /// the specified error message.
-        /// </summary>
-        /// <param name="message">The exception message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        public OpenApiAccessControlPolicyEvaluationFailedException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-            this.AddProblemDetails();
-        }
-
         /// <summary>
         /// Creates a new instance of <see cref="OpenApiAccessControlPolicyEvaluationFailedException"/> with
         /// the specified error message.
@@ -65,18 +30,6 @@ namespace Menes.Exceptions
             this.Requests = requests;
 
             this.AddProblemDetails();
-        }
-
-        /// <summary>Constructor used by .NET serialization infrastructure..</summary>
-        /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="StreamingContext"></see> that contains contextual information about the source or destination.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="info">info</paramref> parameter is null.</exception>
-        /// <exception cref="SerializationException">The class name is null or <see cref="P:System.Exception.HResult"></see> is zero (0).</exception>
-        protected OpenApiAccessControlPolicyEvaluationFailedException(
-            SerializationInfo info,
-            StreamingContext context)
-            : base(info, context)
-        {
         }
 
         /// <summary>
@@ -97,7 +50,7 @@ namespace Menes.Exceptions
 
             if (!string.IsNullOrEmpty(this.PolicyName))
             {
-                this.AddProblemDetailsExtension("Policy Name", this.PolicyName);
+                this.AddProblemDetailsExtension("Policy Name", this.PolicyName!); // ! required as netstandard2.0 lacks nullable attributes
             }
 
             if (this.Requests?.Length > 0)

--- a/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiBadRequestException.cs
+++ b/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiBadRequestException.cs
@@ -5,7 +5,6 @@
 namespace Menes.Exceptions
 {
     using System;
-    using System.Runtime.Serialization;
 
     /// <summary>
     /// An exception which, when thrown from an <see cref="IOpenApiService"/> operation method,
@@ -73,8 +72,8 @@ namespace Menes.Exceptions
         public OpenApiBadRequestException(
             string title,
             string explanation,
-            string detailsType = null,
-            string detailsInstance = null)
+            string? detailsType = null,
+            string? detailsInstance = null)
             : base(title)
         {
             this.AddProblemDetailsTitle(title);
@@ -95,48 +94,19 @@ namespace Menes.Exceptions
             }
         }
 
-        /// <summary>Constructor used by .NET serialization infrastructure..</summary>
-        /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="StreamingContext"></see> that contains contextual information about the source or destination.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="info">info</paramref> parameter is null.</exception>
-        /// <exception cref="SerializationException">The class name is null or <see cref="P:System.Exception.HResult"></see> is zero (0).</exception>
-        protected OpenApiBadRequestException(
-          SerializationInfo info,
-          StreamingContext context)
-            : base(info, context)
-        {
-        }
-
-        /// <summary>
-        /// Standard constructor for any derived exceptions.
-        /// </summary>
-        protected OpenApiBadRequestException()
-        {
-        }
-
-        /// <summary>
-        /// Standard constructor for any derived exceptions.
-        /// </summary>
-        /// <param name="message">The exception message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        protected OpenApiBadRequestException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
         /// <summary>
         /// Gets the detailed explanation of the problem, if present.
         /// </summary>
-        public string Explanation { get; }
+        public string? Explanation { get; }
 
         /// <summary>
         /// Gets the URI identifying the problem type, if present.
         /// </summary>
-        public string DetailsType { get; }
+        public string? DetailsType { get; }
 
         /// <summary>
         /// Gets the URI identifying the problem instance, if present.
         /// </summary>
-        public string DetailsInstance { get; }
+        public string? DetailsInstance { get; }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiForbiddenException.cs
+++ b/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiForbiddenException.cs
@@ -5,7 +5,6 @@
 namespace Menes.Exceptions
 {
     using System;
-    using System.Runtime.Serialization;
 
     /// <summary>
     /// An exception which, when thrown from an <see cref="IOpenApiService"/> operation method,
@@ -17,37 +16,8 @@ namespace Menes.Exceptions
     /// service has determined that the client is not allowed to do whatever it is trying to do.
     /// </para>
     /// </remarks>
-    public class OpenApiForbiddenException : Exception
+    public sealed class OpenApiForbiddenException : Exception
     {
-        /// <summary>
-        /// Standard constructor for any derived exceptions.
-        /// </summary>
-        protected OpenApiForbiddenException()
-        {
-        }
-
-        /// <summary>
-        /// Standard constructor for any derived exceptions.
-        /// </summary>
-        /// <param name="message">The exception message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        protected OpenApiForbiddenException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        /// <summary>Constructor used by .NET serialization infrastructure..</summary>
-        /// <param name="info">The <see cref="SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="StreamingContext"></see> that contains contextual information about the source or destination.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="info">info</paramref> parameter is null.</exception>
-        /// <exception cref="SerializationException">The class name is null or <see cref="P:System.Exception.HResult"></see> is zero (0).</exception>
-        protected OpenApiForbiddenException(
-          SerializationInfo info,
-          StreamingContext context)
-            : base(info, context)
-        {
-        }
-
         /// <summary>Creates a <see cref="OpenApiForbiddenException"/> with a specified error message.</summary>
         /// <param name="message">The message that describes the error.</param>
         private OpenApiForbiddenException(string message)
@@ -80,7 +50,7 @@ namespace Menes.Exceptions
         /// <returns>A new <see cref="OpenApiForbiddenException"/>.</returns>
         public static OpenApiForbiddenException WithProblemDetails(
             string title,
-            string explanation = null)
+            string? explanation = null)
         {
             var result = new OpenApiForbiddenException(title);
             result.AddProblemDetailsTitle(title);

--- a/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiLinkResolutionException.cs
+++ b/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiLinkResolutionException.cs
@@ -9,57 +9,18 @@ namespace Menes.Exceptions
     /// <summary>
     /// Exception that represents a failure to resolve a named link relation to an OpenApi operation Url.
     /// </summary>
-    [Serializable]
     public class OpenApiLinkResolutionException : Exception
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OpenApiLinkResolutionException"/> class.
-        /// </summary>
-        public OpenApiLinkResolutionException()
-        {
-            this.AddProblemDetails();
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="OpenApiLinkResolutionException"/> class with a specified error message.</summary>
-        /// <param name="message">The message that describes the error.</param>
-        public OpenApiLinkResolutionException(string message)
-            : base(message)
-        {
-            this.AddProblemDetails();
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="OpenApiLinkResolutionException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
-        public OpenApiLinkResolutionException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-            this.AddProblemDetails();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="OpenApiLinkResolutionException"/> class with the supplied information.</summary>
         /// <param name="relationType">The link relation type.</param>
         /// <param name="fullTypeName">The full type name of the owner of the link.</param>
         /// <param name="contentType">The content type of the owner.</param>
-        public OpenApiLinkResolutionException(string relationType, string fullTypeName, string contentType)
+        public OpenApiLinkResolutionException(string relationType, string fullTypeName, string? contentType)
             : base($"Unable to find the Operation Id link rel=\"{relationType}\" with owner of type \"{fullTypeName}\" and contentType \"{contentType ?? "not present"}\". Ensure you have registered an appropriate link map.")
         {
             this.RelationType = relationType;
             this.FullTypeName = fullTypeName;
             this.ContentType = contentType;
-            this.AddProblemDetails();
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="OpenApiLinkResolutionException"/> class with serialized data.</summary>
-        /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="info">info</paramref> parameter is null.</exception>
-        /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"></see> is zero (0).</exception>
-        protected OpenApiLinkResolutionException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
             this.AddProblemDetails();
         }
 
@@ -70,7 +31,7 @@ namespace Menes.Exceptions
         public string FullTypeName { get; }
 
         /// <summary>Gets the content type of the owner.</summary>
-        public string ContentType { get; }
+        public string? ContentType { get; }
 
         private void AddProblemDetails()
         {
@@ -78,20 +39,14 @@ namespace Menes.Exceptions
             this.AddProblemDetailsExplanation(this.Message);
             this.AddProblemDetailsType("/endjin/openapi/errors/link/no-link-map-registered");
 
-            if (!string.IsNullOrEmpty(this.RelationType))
-            {
-                this.AddProblemDetailsExtension("Link relation type", this.RelationType);
-            }
+            this.AddProblemDetailsExtension("Link relation type", this.RelationType);
 
             if (!string.IsNullOrEmpty(this.ContentType))
             {
-                this.AddProblemDetailsExtension("Owner ContentType", this.ContentType);
+                this.AddProblemDetailsExtension("Owner ContentType", this.ContentType!); // ! required as netstandard2.0 lacks nullable attributes
             }
 
-            if (!string.IsNullOrEmpty(this.FullTypeName))
-            {
-                this.AddProblemDetailsExtension("Owner CLR type", this.FullTypeName);
-            }
+            this.AddProblemDetailsExtension("Owner CLR type", this.FullTypeName);
         }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiServiceMismatchException.cs
+++ b/Solutions/Menes.Abstractions/Menes/Exceptions/OpenApiServiceMismatchException.cs
@@ -28,7 +28,6 @@ namespace Menes.Exceptions
     /// rather than being thrown on startup.
     /// </para>
     /// </remarks>
-    [Serializable]
     public class OpenApiServiceMismatchException : Exception
     {
         /// <summary>
@@ -37,35 +36,6 @@ namespace Menes.Exceptions
         /// <param name="message">A description of the error.</param>
         public OpenApiServiceMismatchException(string message)
             : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Standard constructor for any derived exceptions.
-        /// </summary>
-        protected OpenApiServiceMismatchException()
-        {
-        }
-
-        /// <summary>
-        /// Standard constructor for any derived exceptions.
-        /// </summary>
-        /// <param name="message">The exception message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        protected OpenApiServiceMismatchException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="OpenApiServiceMismatchException"/> class with serialized data.</summary>
-        /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"></see> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"></see> that contains contextual information about the source or destination.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="info">info</paramref> parameter is null.</exception>
-        /// <exception cref="System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"></see> is zero (0).</exception>
-        protected OpenApiServiceMismatchException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/Solutions/Menes.Abstractions/Menes/Exceptions/OutputBuilderNotFoundException.cs
+++ b/Solutions/Menes.Abstractions/Menes/Exceptions/OutputBuilderNotFoundException.cs
@@ -4,7 +4,6 @@
 
 namespace Menes.Internal
 {
-    using System;
     using System.Collections.Generic;
     using System.Text;
     using Microsoft.OpenApi.Exceptions;
@@ -13,32 +12,6 @@ namespace Menes.Internal
     /// <inheritdoc/>
     public class OutputBuilderNotFoundException : OpenApiException
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OutputBuilderNotFoundException"/> class.
-        /// </summary>
-        public OutputBuilderNotFoundException()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OutputBuilderNotFoundException"/> class.
-        /// </summary>
-        /// <param name="message">The message.</param>
-        public OutputBuilderNotFoundException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OutputBuilderNotFoundException"/> class.
-        /// </summary>
-        /// <param name="message">The message. </param>
-        /// <param name="innerException">The inner exception.</param>
-        public OutputBuilderNotFoundException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="OutputBuilderNotFoundException"/> class.
         /// </summary>
@@ -93,7 +66,7 @@ namespace Menes.Internal
         /// <summary>
         /// Gets the OpenApiResult.
         /// </summary>
-        public OpenApiResult OpenApiResult { get; }
+        public OpenApiResult? OpenApiResult { get; }
 
         /// <summary>
         /// Gets the Operation.

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiConfiguration.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiConfiguration.cs
@@ -36,7 +36,7 @@ namespace Menes
         /// <summary>
         /// Gets or sets the <see cref="JsonSerializerSettings"/>.
         /// </summary>
-        JsonSerializerSettings SerializerSettings { get; set; }
+        JsonSerializerSettings? SerializerSettings { get; set; }
 
         /// <summary>
         /// Gets or sets the discriminator to type mappings. These allow you to define descriminator values

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiContext.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiContext.cs
@@ -14,16 +14,16 @@ namespace Menes
         /// <summary>
         /// Gets or sets the current principal for the request.
         /// </summary>
-        ClaimsPrincipal CurrentPrincipal { get; set; }
+        ClaimsPrincipal? CurrentPrincipal { get; set; }
 
         /// <summary>
         /// Gets or sets the current tenant ID for the request.
         /// </summary>
-        string CurrentTenantId { get; set;  }
+        string? CurrentTenantId { get; set;  }
 
         /// <summary>
         /// Gets or sets additional context for the request.
         /// </summary>
-        object AdditionalContext { get; set;  }
+        object? AdditionalContext { get; set;  }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiDocumentProvider.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiDocumentProvider.cs
@@ -39,7 +39,7 @@ namespace Menes
         /// <param name="parameters">The parameters with which to populate the template.</param>
         /// <returns>A string representing the URI for the operation with the supplied parameters.</returns>
         /// <remarks>This will also build any query string parameters.</remarks>
-        ResolvedOperationRequestInfo GetResolvedOperationRequestInfo(string operationId, params (string Name, object Value)[] parameters);
+        ResolvedOperationRequestInfo GetResolvedOperationRequestInfo(string operationId, params (string Name, object? Value)[] parameters);
 
         /// <summary>
         /// Get a URI template for an operation.

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiDocumentProvider.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiDocumentProvider.cs
@@ -4,6 +4,7 @@
 
 namespace Menes
 {
+    using System.Diagnostics.CodeAnalysis;
     using Microsoft.OpenApi.Models;
     using Tavis.UriTemplates;
 
@@ -54,6 +55,6 @@ namespace Menes
         /// <param name="method">The HTTP method (e.g. get, post).</param>
         /// <param name="operationPathTemplate">The <see cref="OpenApiOperationPathTemplate"/>, or null if no match is found.</param>
         /// <returns>True if a match was found.</returns>
-        bool GetOperationPathTemplate(string requestPath, string method, out OpenApiOperationPathTemplate operationPathTemplate);
+        bool GetOperationPathTemplate(string requestPath, string method, [NotNullWhen(true)] out OpenApiOperationPathTemplate? operationPathTemplate);
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiExceptionMap.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiExceptionMap.cs
@@ -24,7 +24,7 @@ namespace Menes
         /// <typeparam name="TFormatter">
         ///     The type of formatter for the exception mapping.
         /// </typeparam>
-        void Map<TException, TFormatter>(int statusCode, string operationId = null)
+        void Map<TException, TFormatter>(int statusCode, string? operationId = null)
             where TException : Exception
             where TFormatter : IExceptionMapper;
 
@@ -56,7 +56,7 @@ namespace Menes
         ///         you are not allowed to map any exception type to the 500 status code.
         ///     </para>
         /// </remarks>
-        void Map<TException>(int statusCode, string operationId = null)
+        void Map<TException>(int statusCode, string? operationId = null)
             where TException : Exception;
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/IOpenApiExternalServices.cs
+++ b/Solutions/Menes.Abstractions/Menes/IOpenApiExternalServices.cs
@@ -38,6 +38,6 @@ namespace Menes
         /// <returns>The URL.</returns>
         Uri ResolveUrl<TService>(
             string operationId,
-            params (string Name, object Value)[] parameters);
+            params (string Name, object? Value)[] parameters);
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Internal/IPathMatcher.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/IPathMatcher.cs
@@ -4,6 +4,8 @@
 
 namespace Menes.Internal
 {
+    using System.Diagnostics.CodeAnalysis;
+
     /// <summary>
     /// An interface implemented by components which attempt to
     /// match a URI against an OpenAPI document.
@@ -17,6 +19,6 @@ namespace Menes.Internal
         /// <param name="method">The original request method.</param>
         /// <param name="operationPathTemplate">The result of the match.</param>
         /// <returns>True if a match was found otherwise false.</returns>
-        bool FindOperationPathTemplate(string path, string method, out OpenApiOperationPathTemplate operationPathTemplate);
+        bool FindOperationPathTemplate(string path, string method, [NotNullWhen(true)] out OpenApiOperationPathTemplate? operationPathTemplate);
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiAccessPolicyAggregator.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiAccessPolicyAggregator.cs
@@ -61,7 +61,7 @@ namespace Menes.Internal
                 request => request,
                 request =>
                 {
-                    (AccessControlPolicyResultType resultType, string explanation) = results.Aggregate(
+                    (AccessControlPolicyResultType resultType, string? explanation) = results.Aggregate(
                     (resultType: AccessControlPolicyResultType.Allowed, explanation: default(string)),
                     (acc, result) =>
                     (CombineResultTypes(acc.resultType, result[request].ResultType),

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiConfiguration.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiConfiguration.cs
@@ -15,7 +15,7 @@ namespace Menes.Internal
     /// </summary>
     public class OpenApiConfiguration : IOpenApiConfiguration
     {
-        private Dictionary<string, Type> discriminators;
+        private Dictionary<string, Type>? discriminators;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IOpenApiConfiguration"/> class.
@@ -35,7 +35,7 @@ namespace Menes.Internal
         public Formatting Formatting { get; set; }
 
         /// <inheritdoc/>
-        public JsonSerializerSettings SerializerSettings { get; set; }
+        public JsonSerializerSettings? SerializerSettings { get; set; }
 
         /// <inheritdoc/>
         public Dictionary<string, Type> DiscriminatedTypes

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentProvider.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentProvider.cs
@@ -74,7 +74,7 @@ namespace Menes
         }
 
         /// <inheritdoc/>
-        public ResolvedOperationRequestInfo GetResolvedOperationRequestInfo(string operationId, params (string Name, object Value)[] parameters)
+        public ResolvedOperationRequestInfo GetResolvedOperationRequestInfo(string operationId, params (string Name, object? Value)[] parameters)
         {
             if (this.logger.IsEnabled(LogLevel.Debug))
             {
@@ -89,7 +89,7 @@ namespace Menes
             var queryString = new StringBuilder();
 
             // TODO: Validate all required parameters are present
-            foreach ((string name, object value) in parameters)
+            foreach ((string name, object? value) in parameters)
             {
                 if (this.logger.IsEnabled(LogLevel.Debug))
                 {

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentProvider.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentProvider.cs
@@ -6,6 +6,7 @@ namespace Menes
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Text;
     using System.Text.Encodings.Web;
@@ -43,7 +44,7 @@ namespace Menes
         private readonly IList<OpenApiPathTemplate> pathTemplates = new List<OpenApiPathTemplate>();
         private readonly ILogger<OpenApiDocumentProvider> logger;
         private readonly List<OpenApiDocument> addedOpenApiDocuments;
-        private IDictionary<string, OpenApiPathTemplate> pathTemplatesByOperationId;
+        private IDictionary<string, OpenApiPathTemplate>? pathTemplatesByOperationId;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenApiDocumentProvider"/> class.
@@ -61,10 +62,15 @@ namespace Menes
             get { return this.addedOpenApiDocuments; }
         }
 
+        private IDictionary<string, OpenApiPathTemplate> PathTemplatesByOperationId
+        {
+            get => this.pathTemplatesByOperationId ??= this.pathTemplates.SelectMany(t => t.PathItem.Operations.Select(o => new { o.Value.OperationId, PathTemplate = t })).ToDictionary(k => k.OperationId, v => v.PathTemplate);
+        }
+
         /// <inheritdoc/>
         public UriTemplate GetUriTemplateForOperation(string operationId)
         {
-            return new UriTemplate(this.pathTemplatesByOperationId[operationId]?.UriTemplate.ToString());
+            return new UriTemplate(this.PathTemplatesByOperationId[operationId]?.UriTemplate.ToString());
         }
 
         /// <inheritdoc/>
@@ -75,7 +81,7 @@ namespace Menes
                 this.logger.LogDebug("Getting URI for [{operation}]", operationId);
             }
 
-            OpenApiPathTemplate pathTemplate = this.pathTemplatesByOperationId[operationId];
+            OpenApiPathTemplate pathTemplate = this.PathTemplatesByOperationId[operationId];
             KeyValuePair<OperationType, OpenApiOperation> operation = pathTemplate.PathItem.Operations.First(x => x.Value.OperationId == operationId);
             UrlEncoder encoder = UrlEncoder.Default;
             var template = new UriTemplate(pathTemplate.UriTemplate.ToString());
@@ -112,11 +118,9 @@ namespace Menes
                 }
             }
 
-            return new ResolvedOperationRequestInfo
-            {
-                Uri = template.Resolve() + queryString.ToString(),
-                OperationType = operation.Key,
-            };
+            return new ResolvedOperationRequestInfo(
+                template.Resolve() + queryString.ToString(),
+                operation.Key);
         }
 
         /// <summary>
@@ -134,7 +138,7 @@ namespace Menes
 
             this.addedOpenApiDocuments.Add(document);
             this.pathTemplates.AddRange(document.Paths.Select(path => new OpenApiPathTemplate(path.Key, path.Value)));
-            this.pathTemplatesByOperationId = this.pathTemplates.SelectMany(t => t.PathItem.Operations.Select(o => new { o.Value.OperationId, PathTemplate = t })).ToDictionary(k => k.OperationId, v => v.PathTemplate);
+            this.pathTemplatesByOperationId = null;
             if (this.logger.IsEnabled(LogLevel.Trace))
             {
                 this.logger.LogTrace("Added Document [{document}] to template provider", document.Info?.Title ?? "No title provided.");
@@ -142,7 +146,7 @@ namespace Menes
         }
 
         /// <inheritdoc/>
-        public bool GetOperationPathTemplate(string requestPath, string method, out OpenApiOperationPathTemplate operationPathTemplate)
+        public bool GetOperationPathTemplate(string requestPath, string method, [NotNullWhen(true)] out OpenApiOperationPathTemplate? operationPathTemplate)
         {
             foreach (OpenApiPathTemplate template in this.pathTemplates)
             {

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiExceptionMapper.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiExceptionMapper.cs
@@ -38,24 +38,18 @@ namespace Menes.Internal
         }
 
         /// <inheritdoc />
-        public void Map<TException>(int statusCode, string operationId = null)
+        public void Map<TException>(int statusCode, string? operationId = null)
             where TException : Exception
         {
             Type type = typeof(TException);
 
             this.ValidateStatusCode(statusCode);
             this.ValidateMappingDoesNotExist(type, operationId);
-            this.exceptionMappings.Add(new OpenApiMappedException
-            {
-                ExceptionType = type,
-                FormatterType = null,
-                OperationId = operationId,
-                StatusCode = statusCode,
-            });
+            this.exceptionMappings.Add(new OpenApiMappedException(type, statusCode, operationId));
         }
 
         /// <inheritdoc cref="Map{TException}" />
-        public void Map<TException, TFormatter>(int statusCode, string operationId = null)
+        public void Map<TException, TFormatter>(int statusCode, string? operationId = null)
             where TException : Exception
             where TFormatter : IExceptionMapper
         {
@@ -63,13 +57,7 @@ namespace Menes.Internal
 
             this.ValidateStatusCode(statusCode);
             this.ValidateMappingDoesNotExist(type, operationId);
-            this.exceptionMappings.Add(new OpenApiMappedException
-            {
-                ExceptionType = type,
-                FormatterType = typeof(TFormatter),
-                OperationId = operationId,
-                StatusCode = statusCode,
-            });
+            this.exceptionMappings.Add(new OpenApiMappedException(type, statusCode, operationId, typeof(TFormatter)));
         }
 
         /// <inheritdoc/>
@@ -98,7 +86,7 @@ namespace Menes.Internal
                    this.exceptionMappings.FirstOrDefault(x => x.ExceptionType == exceptionType && string.IsNullOrEmpty(x.OperationId));
         }
 
-        private void ValidateMappingDoesNotExist(Type exceptionType, string operationId)
+        private void ValidateMappingDoesNotExist(Type exceptionType, string? operationId)
         {
             if (this.exceptionMappings.Any(x => x.ExceptionType == exceptionType && x.OperationId == operationId))
             {

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiExternalServices.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiExternalServices.cs
@@ -55,7 +55,7 @@ namespace Menes.Internal
         }
 
         /// <inheritdoc />
-        public Uri ResolveUrl<TService>(string operationId, params (string Name, object Value)[] parameters)
+        public Uri ResolveUrl<TService>(string operationId, params (string Name, object? Value)[] parameters)
         {
             Type serviceType = typeof(TService);
             if (!this.uriTemplateProviders.TryGetValue(serviceType, out (OpenApiDocumentProvider Provider, string ConfigKey) providerAndKey))

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiMappedException.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiMappedException.cs
@@ -12,23 +12,42 @@ namespace Menes.Internal
     internal class OpenApiMappedException
     {
         /// <summary>
-        ///     Gets or sets the type of exception to map.
+        /// Creates a <see cref="OpenApiMappedException"/>.
         /// </summary>
-        public Type ExceptionType { get; set; }
+        /// <param name="exceptionType">The <see cref="ExceptionType"/>.</param>
+        /// <param name="statusCode">The <see cref="StatusCode"/>.</param>
+        /// <param name="operationId">The <see cref="OperationId"/>.</param>
+        /// <param name="formatterType">The <see cref="FormatterType"/>.</param>
+        internal OpenApiMappedException(
+            Type exceptionType,
+            int statusCode,
+            string? operationId = null,
+            Type? formatterType = null)
+        {
+            this.ExceptionType = exceptionType;
+            this.StatusCode = statusCode;
+            this.FormatterType = formatterType;
+            this.OperationId = operationId;
+        }
 
         /// <summary>
-        ///     Gets or sets the formatter to use to convert the exception to a response body.
+        ///     Gets the type of exception to map.
         /// </summary>
-        public Type FormatterType { get; set; }
+        public Type ExceptionType { get; }
 
         /// <summary>
-        ///     Gets or sets the operation id that this applies to.
+        ///     Gets the formatter to use to convert the exception to a response body.
         /// </summary>
-        public string OperationId { get; set; }
+        public Type? FormatterType { get; }
 
         /// <summary>
-        ///     Gets or sets the response code to return.
+        ///     Gets the operation id that this applies to.
         /// </summary>
-        public int StatusCode { get; set; }
+        public string? OperationId { get; }
+
+        /// <summary>
+        ///     Gets the response code to return.
+        /// </summary>
+        public int StatusCode { get; }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiServiceOperation.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiServiceOperation.cs
@@ -6,6 +6,7 @@ namespace Menes.Internal
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
     using Newtonsoft.Json;
@@ -84,7 +85,7 @@ namespace Menes.Internal
                 {
                     paramArray[index] = context;
                 }
-                else if (inputParameters.TryGetValue(parameterName, out object value)
+                else if (inputParameters.TryGetValue(parameterName, out object? value)
                     || (this.configuration.EnableNonExactParameterMatching
                      && TryGetInputParameterWithNonExactMatch(inputParameters, parameterName, out value)))
                 {
@@ -143,7 +144,7 @@ namespace Menes.Internal
         private static bool TryGetInputParameterWithNonExactMatch(
             IDictionary<string, object> inputParameters,
             string parameterName,
-            out object value)
+            [NotNullWhen(true)] out object? value)
         {
             value = null;
             string canonicalizedName = CanonicalizeParameterNameForMatching(parameterName);

--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiWebLinkResolver.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiWebLinkResolver.cs
@@ -28,7 +28,10 @@ namespace Menes.Internal
         }
 
         /// <inheritdoc/>
-        public OpenApiWebLink ResolveByOwnerAndRelationType(object owner, string relationType, params (string, object)[] parameters)
+        public OpenApiWebLink ResolveByOwnerAndRelationType(
+            object owner,
+            string relationType,
+            params (string, object?)[] parameters)
         {
             if (this.linkOperationMapper.TryGetOperationId(owner, relationType, out string operationId))
             {
@@ -43,7 +46,11 @@ namespace Menes.Internal
         }
 
         /// <inheritdoc/>
-        public OpenApiWebLink ResolveByOwnerAndRelationTypeAndContext(object owner, string relationType, string context, params (string, object)[] parameters)
+        public OpenApiWebLink ResolveByOwnerAndRelationTypeAndContext(
+            object owner,
+            string relationType,
+            string context,
+            params (string, object?)[] parameters)
         {
             if (this.linkOperationMapper.TryGetOperationId(owner, relationType, context, out string operationId))
             {
@@ -58,7 +65,10 @@ namespace Menes.Internal
         }
 
         /// <inheritdoc/>
-        public OpenApiWebLink ResolveByOperationIdAndRelationType(string operationId, string relationType, params (string, object)[] parameters)
+        public OpenApiWebLink ResolveByOperationIdAndRelationType(
+            string operationId,
+            string relationType,
+            params (string, object?)[] parameters)
         {
             ResolvedOperationRequestInfo operation = this.templateProvider.GetResolvedOperationRequestInfo(operationId, parameters);
             return new OpenApiWebLink(operationId, operation.Uri, operation.OperationType);

--- a/Solutions/Menes.Abstractions/Menes/Internal/PathMatcher.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/PathMatcher.cs
@@ -4,6 +4,8 @@
 
 namespace Menes.Internal
 {
+    using System.Diagnostics.CodeAnalysis;
+
     /// <summary>
     /// Default implementation of a path matcher.
     /// </summary>
@@ -21,7 +23,7 @@ namespace Menes.Internal
         }
 
         /// <inheritdoc/>
-        public bool FindOperationPathTemplate(string path, string method, out OpenApiOperationPathTemplate operationPathTemplate)
+        public bool FindOperationPathTemplate(string path, string method, [NotNullWhen(true)] out OpenApiOperationPathTemplate? operationPathTemplate)
         {
             return this.templateProvider.GetOperationPathTemplate(path, method, out operationPathTemplate);
         }

--- a/Solutions/Menes.Abstractions/Menes/Links/IOpenApiWebLinkResolver.cs
+++ b/Solutions/Menes.Abstractions/Menes/Links/IOpenApiWebLinkResolver.cs
@@ -39,7 +39,10 @@ namespace Menes.Links
         /// content types instead.
         /// </para>
         /// </remarks>
-        OpenApiWebLink ResolveByOwnerAndRelationType(object owner, string relationType, params (string, object)[] parameters);
+        OpenApiWebLink ResolveByOwnerAndRelationType(
+            object owner,
+            string relationType,
+            params (string, object?)[] parameters);
 
         /// <summary>
         /// Resolves the url for the given link and returns an <see cref="OpenApiWebLink"/> containing
@@ -71,7 +74,11 @@ namespace Menes.Links
         /// content types instead.
         /// </para>
         /// </remarks>
-        OpenApiWebLink ResolveByOwnerAndRelationTypeAndContext(object owner, string relationType, string context, params (string, object)[] parameters);
+        OpenApiWebLink ResolveByOwnerAndRelationTypeAndContext(
+            object owner,
+            string relationType,
+            string context,
+            params (string, object?)[] parameters);
 
         /// <summary>
         /// Resolves the url for the given link and returns an <see cref="OpenApiWebLink"/> containing
@@ -81,6 +88,9 @@ namespace Menes.Links
         /// <param name="relationType">The link relation type. This is the "rel" attribute for the link.</param>
         /// <param name="parameters">Any parameters which are needed to build the link.</param>
         /// <returns>The resolved <see cref="OpenApiWebLink"/>.</returns>
-        OpenApiWebLink ResolveByOperationIdAndRelationType(string operationId, string relationType, params (string, object)[] parameters);
+        OpenApiWebLink ResolveByOperationIdAndRelationType(
+            string operationId,
+            string relationType,
+            params (string, object?)[] parameters);
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Links/LinkCollectionExtensions.cs
+++ b/Solutions/Menes.Abstractions/Menes/Links/LinkCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Menes.Links
             IOpenApiWebLinkResolver linkResolver,
             object owner,
             string relationType,
-            params (string, object)[] parameters)
+            params (string, object?)[] parameters)
         {
             OpenApiWebLink link = linkResolver.ResolveByOwnerAndRelationType(owner, relationType, parameters);
             linkCollection.AddLink(relationType, link);
@@ -46,7 +46,7 @@ namespace Menes.Links
             object owner,
             string relationType,
             string context,
-            params (string, object)[] parameters)
+            params (string, object?)[] parameters)
         {
             OpenApiWebLink link = linkResolver.ResolveByOwnerAndRelationTypeAndContext(owner, relationType, context, parameters);
             linkCollection.AddLink(relationType, link);
@@ -67,7 +67,7 @@ namespace Menes.Links
             IOpenApiWebLinkResolver linkResolver,
             string operationId,
             string relationType,
-            params (string, object)[] parameters)
+            params (string, object?)[] parameters)
         {
             OpenApiWebLink link = linkResolver.ResolveByOperationIdAndRelationType(operationId, relationType, parameters);
             linkCollection.AddLink(relationType, link);

--- a/Solutions/Menes.Abstractions/Menes/Links/WebLink.cs
+++ b/Solutions/Menes.Abstractions/Menes/Links/WebLink.cs
@@ -11,15 +11,8 @@ namespace Menes.Links
     /// Represents a hypermedia link to a related resource. Follows the general pattern described
     /// in RFC 8288 (https://tools.ietf.org/html/rfc8288).
     /// </summary>
-    public class WebLink : IEquatable<WebLink>
+    public class WebLink : IEquatable<WebLink?>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WebLink"/> struct.
-        /// </summary>
-        public WebLink()
-        {
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="WebLink"/> struct.
         /// </summary>
@@ -30,7 +23,7 @@ namespace Menes.Links
         /// <param name="profile">Additional semantics of the target resource..</param>
         /// <param name="title">the human-readable title of the link.</param>
         /// <param name="type">The media type indication of the target resource.</param>
-        public WebLink(string href, string name = null, bool? isTemplated = null, string hreflang = null, string profile = null, string title = null, string type = null)
+        public WebLink(string href, string? name = null, bool? isTemplated = null, string? hreflang = null, string? profile = null, string? title = null, string? type = null)
         {
             this.Href = href;
             this.Name = name;
@@ -57,7 +50,7 @@ namespace Menes.Links
         /// When present, may be used as a secondary key for selecting link
         /// objects that contain the same relation type.
         /// </remarks>
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets a value that indicates whether the link is templated (or null if the property is not set).
@@ -77,7 +70,7 @@ namespace Menes.Links
         /// in the language indicated by the Content-Language header (if
         /// present).
         /// </remarks>
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
         /// <summary>
         /// Gets or sets additional semantics of the target resource.
@@ -89,7 +82,7 @@ namespace Menes.Links
         /// resource representation, in addition to those defined by the HAL
         /// media type and relations.
         /// </remarks>
-        public string Profile { get; set; }
+        public string? Profile { get; set; }
 
         /// <summary>
         /// Gets or sets media type indication of the target resource.
@@ -98,7 +91,7 @@ namespace Menes.Links
         /// When present, used as a hint to indicate the media type expected
         /// when dereferencing the target resource.
         /// </remarks>
-        public string Type { get; set; }
+        public string? Type { get; set; }
 
         /// <summary>
         /// Gets or sets language indication of the target resource [RFC5988].
@@ -110,7 +103,7 @@ namespace Menes.Links
         /// Content-Language header of a HTTP response obtained by actually
         /// following the link.
         /// </remarks>
-        public string Hreflang { get; set; }
+        public string? Hreflang { get; set; }
 
         /// <summary>
         /// Standard equality operator.
@@ -118,9 +111,9 @@ namespace Menes.Links
         /// <param name="left">The left hand side of the comparison.</param>
         /// <param name="right">The right hand side of the comparison.</param>
         /// <returns>True if the links are equivalent.</returns>
-        public static bool operator ==(WebLink left, WebLink right)
+        public static bool operator ==(WebLink? left, WebLink? right)
         {
-            return EqualityComparer<WebLink>.Default.Equals(left, right);
+            return EqualityComparer<WebLink?>.Default.Equals(left, right);
         }
 
         /// <summary>
@@ -129,7 +122,7 @@ namespace Menes.Links
         /// <param name="left">The left hand side of the comparison.</param>
         /// <param name="right">The right hand side of the comparison.</param>
         /// <returns>True if the links are not equivalent.</returns>
-        public static bool operator !=(WebLink left, WebLink right)
+        public static bool operator !=(WebLink? left, WebLink? right)
         {
             return !(left == right);
         }
@@ -141,7 +134,7 @@ namespace Menes.Links
         }
 
         /// <inheritdoc/>
-        public bool Equals(WebLink other)
+        public bool Equals(WebLink? other)
         {
             return other != null &&
                    this.Href == other.Href &&

--- a/Solutions/Menes.Abstractions/Menes/OpenApiServiceExtensions.cs
+++ b/Solutions/Menes.Abstractions/Menes/OpenApiServiceExtensions.cs
@@ -142,7 +142,11 @@ namespace Menes
         /// <param name="parameters">The parameters for the link.</param>
         /// <returns>An OpenApi result with the Created status code and Location header.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "For symmetry with other extension methods")]
-        public static OpenApiResult CreatedResult(this IOpenApiService service, IOpenApiWebLinkResolver linkResolver, string operationId, params (string, object)[] parameters)
+        public static OpenApiResult CreatedResult(
+            this IOpenApiService service,
+            IOpenApiWebLinkResolver linkResolver,
+            string operationId,
+            params (string, object?)[] parameters)
         {
             OpenApiWebLink link = linkResolver.ResolveByOperationIdAndRelationType(operationId, "self", parameters);
             return new OpenApiResult
@@ -162,7 +166,11 @@ namespace Menes
         /// <param name="contentType">The content type of the response (defaults to application/json).</param>
         /// <returns>An OpenApi result with the Created status code and the object in the response body against the relevant content type.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "For symmetry with other extension methods")]
-        public static OpenApiResult CreatedResult<T>(this IOpenApiService service, string location, [DisallowNull] T result, string? contentType = null)
+        public static OpenApiResult CreatedResult<T>(
+            this IOpenApiService service,
+            string location,
+            [DisallowNull] T result,
+            string? contentType = null)
         {
             return new OpenApiResult
             {

--- a/Solutions/Menes.Abstractions/Menes/OpenApiServiceExtensions.cs
+++ b/Solutions/Menes.Abstractions/Menes/OpenApiServiceExtensions.cs
@@ -6,6 +6,7 @@
 
 namespace Menes
 {
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Net;
     using Corvus.ContentHandling;
@@ -24,7 +25,7 @@ namespace Menes
         /// <returns>The <see cref="OpenApiResult"/> with audit data added.</returns>
         public static OpenApiResult WithAuditData(this OpenApiResult result, params (string, object)[] auditData)
         {
-            result.AuditData = auditData?.ToDictionary(x => x.Item1, x => x.Item2);
+            result.AuditData = auditData.ToDictionary(x => x.Item1, x => x.Item2);
             return result;
         }
 
@@ -37,12 +38,12 @@ namespace Menes
         /// <param name="contentType">The content type of the response (defaults to application/json).</param>
         /// <returns>An OpenApi result with the OK status code and the object in the response body against the relevant content type.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "For symmetry with other extension methods")]
-        public static OpenApiResult OkResult<T>(this IOpenApiService service, T result, string contentType = null)
+        public static OpenApiResult OkResult<T>(this IOpenApiService service, [DisallowNull] T result, string? contentType = null)
         {
             return new OpenApiResult
             {
                 StatusCode = (int)HttpStatusCode.OK,
-                Results = { { GetContentType(result, contentType), result } },
+                Results = { { GetContentType(result, contentType), result! } },
             };
         }
 
@@ -161,12 +162,12 @@ namespace Menes
         /// <param name="contentType">The content type of the response (defaults to application/json).</param>
         /// <returns>An OpenApi result with the Created status code and the object in the response body against the relevant content type.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "For symmetry with other extension methods")]
-        public static OpenApiResult CreatedResult<T>(this IOpenApiService service, string location, T result, string contentType = null)
+        public static OpenApiResult CreatedResult<T>(this IOpenApiService service, string location, [DisallowNull] T result, string? contentType = null)
         {
             return new OpenApiResult
             {
                 StatusCode = (int)HttpStatusCode.Created,
-                Results = { { "Location", location }, { GetContentType(result, contentType), result } },
+                Results = { { "Location", location }, { GetContentType(result, contentType), result! } },
             };
         }
 
@@ -214,12 +215,12 @@ namespace Menes
             };
         }
 
-        private static string GetContentType<T>(T instance, string contentType)
+        private static string GetContentType<T>(T instance, string? contentType)
         {
             return contentType ?? GetContentTypeOrNull(instance) ?? "application/json";
         }
 
-        private static string GetContentTypeOrNull<T>(T instance)
+        private static string? GetContentTypeOrNull<T>(T instance)
         {
             return ContentFactory.TryGetContentType(instance, out string contentType) ? contentType : null;
         }

--- a/Solutions/Menes.Abstractions/Menes/ResolvedOperationRequestInfo.cs
+++ b/Solutions/Menes.Abstractions/Menes/ResolvedOperationRequestInfo.cs
@@ -13,15 +13,28 @@ namespace Menes
     public class ResolvedOperationRequestInfo
     {
         /// <summary>
-        /// Gets or sets the resolved Uri of the operation. This is created from the path
-        /// template of the operation and any values needed to populate path and query parameters.
+        /// Creates a <see cref="ResolvedOperationRequestInfo"/>.
         /// </summary>
-        public string Uri { get; set; }
+        /// <param name="uri">The <see cref="Uri"/>.</param>
+        /// <param name="operationType">The <see cref="OperationType"/>.</param>
+        public ResolvedOperationRequestInfo(
+            string uri,
+            OperationType operationType)
+        {
+            this.Uri = uri;
+            this.OperationType = operationType;
+        }
 
         /// <summary>
-        /// Gets or sets the <see cref="OperationType"/> that should be used with the
+        /// Gets the resolved Uri of the operation. This is created from the path
+        /// template of the operation and any values needed to populate path and query parameters.
+        /// </summary>
+        public string Uri { get; }
+
+        /// <summary>
+        /// Gets the <see cref="OperationType"/> that should be used with the
         /// <see cref="Uri"/> to access the operation. This corresponds to an Http method.
         /// </summary>
-        public OperationType OperationType { get; set; }
+        public OperationType OperationType { get; }
     }
 }

--- a/Solutions/Menes.Abstractions/Menes/Validation/ChildSchemaValidationError.cs
+++ b/Solutions/Menes.Abstractions/Menes/Validation/ChildSchemaValidationError.cs
@@ -18,13 +18,13 @@ namespace Menes.Validation
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildSchemaValidationError"/> class.</summary>
         /// <param name="kind">The error kind. </param>
-        /// <param name="property">The property name. </param>
+        /// <param name="propertyName">The property name. </param>
         /// <param name="path">The property path. </param>
         /// <param name="errors">The error list. </param>
         /// <param name="token">The token that failed to validate. </param>
         /// <param name="schema">The schema that contains the validation rule.</param>
-        public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IReadOnlyDictionary<OpenApiSchema, ICollection<ValidationError>> errors, JToken token, OpenApiSchema schema)
-            : base(kind, property, path, token, schema)
+        public ChildSchemaValidationError(ValidationErrorKind kind, string? propertyName, string path, IReadOnlyDictionary<OpenApiSchema, ICollection<ValidationError>> errors, JToken token, OpenApiSchema schema)
+            : base(kind, propertyName, path, token, schema)
         {
             this.Errors = errors;
         }

--- a/Solutions/Menes.Abstractions/Menes/Validation/MultiTypeValidationError.cs
+++ b/Solutions/Menes.Abstractions/Menes/Validation/MultiTypeValidationError.cs
@@ -18,13 +18,13 @@ namespace Menes.Validation
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiTypeValidationError"/> class.</summary>
         /// <param name="kind">The error kind. </param>
-        /// <param name="property">The property name. </param>
+        /// <param name="propertyName">The property name. </param>
         /// <param name="path">The property path. </param>
         /// <param name="errors">The error list. </param>
         /// <param name="token">The token that failed to validate. </param>
         /// <param name="schema">The schema that contains the validation rule.</param>
-        public MultiTypeValidationError(ValidationErrorKind kind, string property, string path, IReadOnlyDictionary<JsonObjectType, ICollection<ValidationError>> errors, JToken token, OpenApiSchema schema)
-            : base(kind, property, path, token, schema)
+        public MultiTypeValidationError(ValidationErrorKind kind, string? propertyName, string path, IReadOnlyDictionary<JsonObjectType, ICollection<ValidationError>> errors, JToken token, OpenApiSchema schema)
+            : base(kind, propertyName, path, token, schema)
         {
             this.Errors = errors;
         }

--- a/Solutions/Menes.Abstractions/Menes/Validation/ValidationError.cs
+++ b/Solutions/Menes.Abstractions/Menes/Validation/ValidationError.cs
@@ -18,21 +18,20 @@ namespace Menes.Validation
     {
         /// <summary>Initializes a new instance of the <see cref="ValidationError"/> class. </summary>
         /// <param name="errorKind">The error kind. </param>
-        /// <param name="propertyName">The property name. </param>
+        /// <param name="propertyName">The property name, or null if the failure is at the root level.</param>
         /// <param name="propertyPath">The property path. </param>
         /// <param name="token">The token that failed to validate. </param>
         /// <param name="schema">The schema that contains the validation rule.</param>
-        public ValidationError(ValidationErrorKind errorKind, string propertyName, string propertyPath, JToken token, OpenApiSchema schema)
+        public ValidationError(ValidationErrorKind errorKind, string? propertyName, string propertyPath, JToken token, OpenApiSchema schema)
         {
             this.Kind = errorKind;
             this.Property = propertyName;
             this.Path = propertyPath != null ? "#/" + propertyPath : "#";
 
             var lineInfo = token as IJsonLineInfo;
-            this.HasLineInfo = lineInfo?.HasLineInfo() == true;
-
-            if (this.HasLineInfo)
+            if (lineInfo?.HasLineInfo() == true)
             {
+                this.HasLineInfo = true;
                 this.LineNumber = lineInfo.LineNumber;
                 this.LinePosition = lineInfo.LinePosition;
             }
@@ -50,7 +49,7 @@ namespace Menes.Validation
         public ValidationErrorKind Kind { get; }
 
         /// <summary>Gets the property name. </summary>
-        public string Property { get; }
+        public string? Property { get; }
 
         /// <summary>Gets the property path. </summary>
         public string Path { get; }

--- a/Solutions/Menes.Hosting.AspNetCore/Menes.Hosting.AspNetCore.csproj
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes.Hosting.AspNetCore.csproj
@@ -1,9 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
+
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageDescription>Menes is a framework for hosting Web APIs with OpenAPI-based service definitions. This library defines the ASP.NET-Core-specific aspects of hosting in Menes.</PackageDescription>
+
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +17,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Nullable" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
   </ItemGroup>
 

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/HttpRequestParameterBuilder.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/HttpRequestParameterBuilder.cs
@@ -6,6 +6,7 @@ namespace Menes.Internal
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -57,7 +58,7 @@ namespace Menes.Internal
                 switch (parameter.In)
                 {
                     case ParameterLocation.Cookie:
-                        if (this.TryGetParameterFromCookie(request.Cookies, parameter, out object cookieResult))
+                        if (this.TryGetParameterFromCookie(request.Cookies, parameter, out object? cookieResult))
                         {
                             if (this.logger.IsEnabled(LogLevel.Debug))
                             {
@@ -80,7 +81,7 @@ namespace Menes.Internal
 
                         break;
                     case ParameterLocation.Header:
-                        if (this.TryGetParameterFromHeader(request.Headers, parameter, out object headerResult))
+                        if (this.TryGetParameterFromHeader(request.Headers, parameter, out object? headerResult))
                         {
                             if (this.logger.IsEnabled(LogLevel.Debug))
                             {
@@ -103,7 +104,7 @@ namespace Menes.Internal
 
                         break;
                     case ParameterLocation.Path:
-                        if (this.TryGetParameterFromPath(templateParameterValues, parameter, out object pathResult))
+                        if (this.TryGetParameterFromPath(templateParameterValues, parameter, out object? pathResult))
                         {
                             if (this.logger.IsEnabled(LogLevel.Debug))
                             {
@@ -126,7 +127,7 @@ namespace Menes.Internal
 
                         break;
                     case ParameterLocation.Query:
-                        if (this.TryGetParameterFromQuery(request.Query, parameter, out object queryResult))
+                        if (this.TryGetParameterFromQuery(request.Query, parameter, out object? queryResult))
                         {
                             if (this.logger.IsEnabled(LogLevel.Debug))
                             {
@@ -220,7 +221,7 @@ namespace Menes.Internal
                 }
             }
 
-            string requestBaseContentType = this.GetBaseContentType(request.ContentType);
+            string? requestBaseContentType = this.GetBaseContentType(request.ContentType);
 
             if (string.IsNullOrEmpty(requestBaseContentType) || !operationPathTemplate.Operation.RequestBody.Content.TryGetValue(requestBaseContentType, out OpenApiMediaType openApiMediaType))
             {
@@ -262,7 +263,7 @@ namespace Menes.Internal
             }
         }
 
-        private string GetBaseContentType(string contentType)
+        private string? GetBaseContentType(string contentType)
         {
             if (string.IsNullOrEmpty(contentType))
             {
@@ -274,7 +275,10 @@ namespace Menes.Internal
             return separator != -1 ? contentType.Substring(0, separator) : contentType;
         }
 
-        private bool TryGetParameterFromCookie(IRequestCookieCollection cookies, OpenApiParameter parameter, out object result)
+        private bool TryGetParameterFromCookie(
+            IRequestCookieCollection cookies,
+            OpenApiParameter parameter,
+            [NotNullWhen(true)] out object? result)
         {
             if (this.logger.IsEnabled(LogLevel.Debug))
             {
@@ -331,7 +335,10 @@ namespace Menes.Internal
             return this.ConvertValue(schema, value);
         }
 
-        private bool TryGetParameterFromHeader(IHeaderDictionary headers, OpenApiParameter parameter, out object result)
+        private bool TryGetParameterFromHeader(
+            IHeaderDictionary headers,
+            OpenApiParameter parameter,
+            [NotNullWhen(true)] out object? result)
         {
             if (this.logger.IsEnabled(LogLevel.Debug))
             {
@@ -377,7 +384,10 @@ namespace Menes.Internal
             return false;
         }
 
-        private bool TryGetParameterFromPath(IDictionary<string, object> templateParameters, OpenApiParameter parameter, out object result)
+        private bool TryGetParameterFromPath(
+            IDictionary<string, object> templateParameters,
+            OpenApiParameter parameter,
+            [NotNullWhen(true)] out object? result)
         {
             if (this.logger.IsEnabled(LogLevel.Debug))
             {
@@ -423,7 +433,10 @@ namespace Menes.Internal
             return false;
         }
 
-        private bool TryGetParameterFromQuery(IQueryCollection query, OpenApiParameter parameter, out object result)
+        private bool TryGetParameterFromQuery(
+            IQueryCollection query,
+            OpenApiParameter parameter,
+            [NotNullWhen(true)] out object? result)
         {
             if (this.logger.IsEnabled(LogLevel.Debug))
             {

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/OpenApiActionResult.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/OpenApiActionResult.cs
@@ -283,7 +283,7 @@ namespace Menes.Internal
 
                 if (this.openApiResult.Results.TryGetValue(header.Key, out object value))
                 {
-                    string convertedValue = null;
+                    string? convertedValue = null;
 
                     if (value is Func<string> valueAsFuncOfString)
                     {

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/OpenApiResultActionResultOutputBuilder.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/OpenApiResultActionResultOutputBuilder.cs
@@ -49,7 +49,7 @@ namespace Menes.Internal
 
             // This must have been called after CanBuildOutput(), so we know these casts
             // and lookups will succeed
-            var openApiResult = result as OpenApiResult;
+            var openApiResult = (OpenApiResult)result;
 
             var actionResult = OpenApiActionResult.FromOpenApiResult(openApiResult, operation, this.converters, this.logger);
 

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/SimpleOpenApiContext.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/SimpleOpenApiContext.cs
@@ -12,12 +12,12 @@ namespace Menes
     public class SimpleOpenApiContext : IOpenApiContext
     {
         /// <inheritdoc/>
-        public ClaimsPrincipal CurrentPrincipal { get; set; }
+        public ClaimsPrincipal? CurrentPrincipal { get; set; }
 
         /// <inheritdoc/>
-        public string CurrentTenantId { get; set;  }
+        public string? CurrentTenantId { get; set; }
 
         /// <inheritdoc/>
-        public object AdditionalContext { get; set; }
+        public object? AdditionalContext { get; set; }
     }
 }

--- a/Solutions/Menes.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/OpenApiHttpRequestHostServiceCollectionExtensions.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/OpenApiHttpRequestHostServiceCollectionExtensions.cs
@@ -23,7 +23,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configureHost">A function to configure the host.</param>
         /// <param name="configureEnvironment">A function to configure the environment.</param>
         /// <returns>The configured service collection.</returns>
-        public static IServiceCollection AddOpenApiHttpRequestHosting<TContext>(this IServiceCollection services, Action<IOpenApiHostConfiguration> configureHost, Action<IOpenApiConfiguration> configureEnvironment = null)
+        public static IServiceCollection AddOpenApiHttpRequestHosting<TContext>(
+            this IServiceCollection services,
+            Action<IOpenApiHostConfiguration> configureHost,
+            Action<IOpenApiConfiguration>? configureEnvironment = null)
             where TContext : class, IOpenApiContext, new()
         {
             services.AddSingleton<IActionResultOutputBuilder, PocoActionResultOutputBuilder>();

--- a/Solutions/Menes.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/OpenApiHttpRequestHostServiceCollectionExtensions.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/OpenApiHttpRequestHostServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The configured service collection.</returns>
         public static IServiceCollection AddOpenApiHttpRequestHosting<TContext>(
             this IServiceCollection services,
-            Action<IOpenApiHostConfiguration> configureHost,
+            Action<IOpenApiHostConfiguration>? configureHost,
             Action<IOpenApiConfiguration>? configureEnvironment = null)
             where TContext : class, IOpenApiContext, new()
         {

--- a/Solutions/Menes.Hosting/Menes.Hosting.csproj
+++ b/Solutions/Menes.Hosting/Menes.Hosting.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
+
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageDescription>Menes is a framework for hosting Web APIs with OpenAPI-based service definitions. This library defines the non-technology-specific aspects of hosting in Menes.</PackageDescription>
   </PropertyGroup>

--- a/Solutions/Menes.Hosting/Menes/Internal/OpenApiOperationInvoker.cs
+++ b/Solutions/Menes.Hosting/Menes/Internal/OpenApiOperationInvoker.cs
@@ -205,7 +205,7 @@ namespace Menes.Internal
                 };
                 if (!string.IsNullOrWhiteSpace(result.Explanation))
                 {
-                    x.AddProblemDetailsExplanation(result.Explanation);
+                    x.AddProblemDetailsExplanation(result.Explanation!); // ! required as netstandard2.0 lacks nullable attributes
                 }
 
                 throw x;

--- a/Solutions/Menes.Hosting/Menes/OpenApiHost.cs
+++ b/Solutions/Menes.Hosting/Menes/OpenApiHost.cs
@@ -40,7 +40,7 @@ namespace Menes
             IOpenApiContext context = await this.BuildContextAsync(request, parameters).ConfigureAwait(false);
 
             // Try to find an Open API operation which matches the incoming request.
-            if (this.matcher.FindOperationPathTemplate(path, method, out OpenApiOperationPathTemplate operationPathTemplate))
+            if (this.matcher.FindOperationPathTemplate(path, method, out OpenApiOperationPathTemplate? operationPathTemplate))
             {
                 // Now execute the operation
                 return await this.operationInvoker.InvokeAsync(path, method, request, operationPathTemplate, context).ConfigureAwait(false);

--- a/Solutions/Menes.Hosting/Microsoft/Extensions/DependencyInjection/OpenApiHostingServiceCollectionExtensions.cs
+++ b/Solutions/Menes.Hosting/Microsoft/Extensions/DependencyInjection/OpenApiHostingServiceCollectionExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </remarks>
         public static IServiceCollection AddOpenApiHosting<TRequest, TResponse>(
             this IServiceCollection services,
-            Action<OpenApiHostConfiguration> configureHost,
+            Action<OpenApiHostConfiguration>? configureHost,
             Action<IOpenApiConfiguration>? configureEnvironment = null)
         {
             if (services.Any(s => typeof(IOpenApiHost<TRequest, TResponse>).IsAssignableFrom(s.ServiceType)))

--- a/Solutions/Menes.Hosting/Microsoft/Extensions/DependencyInjection/OpenApiHostingServiceCollectionExtensions.cs
+++ b/Solutions/Menes.Hosting/Microsoft/Extensions/DependencyInjection/OpenApiHostingServiceCollectionExtensions.cs
@@ -85,7 +85,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// See <see cref="IOpenApiService"/> for more details on configuring the host using this mechanism.
         /// </para>
         /// </remarks>
-        public static IServiceCollection AddOpenApiHosting<TRequest, TResponse>(this IServiceCollection services, Action<OpenApiHostConfiguration> configureHost, Action<IOpenApiConfiguration> configureEnvironment = null)
+        public static IServiceCollection AddOpenApiHosting<TRequest, TResponse>(
+            this IServiceCollection services,
+            Action<OpenApiHostConfiguration> configureHost,
+            Action<IOpenApiConfiguration>? configureEnvironment = null)
         {
             if (services.Any(s => typeof(IOpenApiHost<TRequest, TResponse>).IsAssignableFrom(s.ServiceType)))
             {

--- a/Solutions/Menes.PetStore.Hosting/Menes.PetStore.Hosting.csproj
+++ b/Solutions/Menes.PetStore.Hosting/Menes.PetStore.Hosting.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
 
     <IsPackable>false</IsPackable>

--- a/Solutions/Menes.PetStore/Menes.PetStore.csproj
+++ b/Solutions/Menes.PetStore/Menes.PetStore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Solutions/Menes.PetStore/Menes/PetStore/PetStoreService.cs
+++ b/Solutions/Menes.PetStore/Menes/PetStore/PetStoreService.cs
@@ -43,15 +43,15 @@ namespace Menes.PetStore
         {
             this.pets = new List<PetResource>
                             {
-                                new PetResource { Id = 1, Name = "Suki", Tag = "Cat", Size = Size.Small, GlobalIdentifier = Guid.NewGuid() },
-                                new PetResource { Id = 2, Name = "Caspar", Tag = "Dog", Size = Size.Medium, GlobalIdentifier = Guid.NewGuid() },
-                                new PetResource { Id = 3, Name = "Tim", Tag = "Goldfish", Size = Size.Large, GlobalIdentifier = Guid.NewGuid() },
+                                new PetResource("Suki", "Cat") { Id = 1, Size = Size.Small, GlobalIdentifier = Guid.NewGuid() },
+                                new PetResource("Caspar", "Dog") { Id = 2, Size = Size.Medium, GlobalIdentifier = Guid.NewGuid() },
+                                new PetResource("Tim", "Goldfish") { Id = 3, Size = Size.Large, GlobalIdentifier = Guid.NewGuid() },
                             };
 
             this.petListMapper = petListMapper;
             this.petMapper = petMapper;
             this.httpClientFactory = httpClientFactory;
-            this.secretPet = new PetResource { Id = 0, Name = "Yogi", Tag = "Bear", Size = Size.Large, GlobalIdentifier = Guid.NewGuid() };
+            this.secretPet = new PetResource("Yogi", "Bear") { Id = 0, Size = Size.Large, GlobalIdentifier = Guid.NewGuid() };
         }
 
         /// <summary>
@@ -63,14 +63,14 @@ namespace Menes.PetStore
         /// An <see cref="IEnumerable{Pet}"/> containing all pets.
         /// </returns>
         [OperationId("listPets")]
-        public OpenApiResult ListPets(int limit = 10, string continuationToken = null)
+        public OpenApiResult ListPets(int limit = 10, string? continuationToken = null)
         {
             int skip = ParseContinuationToken(continuationToken);
 
             PetResource[] pets = this.pets.Skip(skip).Take(limit).ToArray();
 
-            string nextContinuationToken = (skip + limit < this.pets.Count) ? BuildContinuationToken(limit + skip) : null;
-            HalDocument response = this.petListMapper.Map(new PetListResource { Pets = pets, TotalCount = this.pets.Count, PageSize = limit, CurrentContinuationToken = continuationToken,  NextContinuationToken = nextContinuationToken });
+            string? nextContinuationToken = (skip + limit < this.pets.Count) ? BuildContinuationToken(limit + skip) : null;
+            HalDocument response = this.petListMapper.Map(new PetListResource(pets) { TotalCount = this.pets.Count, PageSize = limit, CurrentContinuationToken = continuationToken,  NextContinuationToken = nextContinuationToken });
 
             OpenApiResult result = this.OkResult(response, "application/hal+json");
 
@@ -239,7 +239,7 @@ namespace Menes.PetStore
             return $"skip={skip}".Base64UrlEncode();
         }
 
-        private static int ParseContinuationToken(string continuationToken)
+        private static int ParseContinuationToken(string? continuationToken)
         {
             if (continuationToken == null)
             {

--- a/Solutions/Menes.PetStore/Menes/PetStore/Responses/PetListResource.cs
+++ b/Solutions/Menes.PetStore/Menes/PetStore/Responses/PetListResource.cs
@@ -12,6 +12,15 @@ namespace Menes.PetStore.Responses
     public class PetListResource
     {
         /// <summary>
+        /// Creates a <see cref="PetListResource"/>.
+        /// </summary>
+        /// <param name="pets">The <see cref="Pets"/>.</param>
+        public PetListResource(PetResource[] pets)
+        {
+            this.Pets = pets;
+        }
+
+        /// <summary>
         /// The registered content type for the pet list resource.
         /// </summary>
         public const string RegisteredContentType = "application/vnd.menes.demo.petlistresource";
@@ -38,13 +47,13 @@ namespace Menes.PetStore.Responses
         /// </summary>
         /// <remarks>The is serialized in the links.</remarks>
         [JsonIgnore]
-        public string CurrentContinuationToken { get; internal set; }
+        public string? CurrentContinuationToken { get; internal set; }
 
         /// <summary>
         /// Gets the current continuation token related to the resource.
         /// </summary>
         /// <remarks>The is serialized in the links.</remarks>
         [JsonIgnore]
-        public string NextContinuationToken { get; internal set; }
+        public string? NextContinuationToken { get; internal set; }
     }
 }

--- a/Solutions/Menes.PetStore/Menes/PetStore/Responses/PetResource.cs
+++ b/Solutions/Menes.PetStore/Menes/PetStore/Responses/PetResource.cs
@@ -19,9 +19,14 @@ namespace Menes.PetStore.Responses
         /// <summary>
         /// Initializes a new instance of the <see cref="PetResource"/> class.
         /// </summary>
-        public PetResource()
+        /// <param name="name">The <see cref="Name"/>.</param>
+        /// <param name="tag">The <see cref="Tag"/>.</param>
+        public PetResource(
+            string name,
+            string tag)
         {
-            this.GlobalIdentifier = Guid.NewGuid();
+            this.Name = name;
+            this.Tag = tag;
         }
 
         /// <summary>

--- a/Solutions/Menes.Specs/Bindings/TestOperationBindings.cs
+++ b/Solutions/Menes.Specs/Bindings/TestOperationBindings.cs
@@ -1,5 +1,6 @@
 ﻿namespace Menes.Specs.Bindings
 {
+    using System;
     using System.Collections.Generic;
     using System.Reflection;
     using System.Threading.Tasks;
@@ -30,7 +31,7 @@
     [Binding]
     public class TestOperationBindings : IOpenApiService
     {
-        private static readonly MethodInfo operationMethodInfo = typeof(TestOperationBindings).GetMethod(nameof(TestOperation), BindingFlags.NonPublic | BindingFlags.Instance);
+        private static readonly MethodInfo operationMethodInfo = typeof(TestOperationBindings).GetMethod(nameof(TestOperation), BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new InvalidOperationException($"Couldn't load method info for {nameof(TestOperation)}");
         private readonly ScenarioContext scenarioContext;
 
         public TestOperationBindings(ScenarioContext scenarioContext)

--- a/Solutions/Menes.Specs/Fakes/ExceptionDetail.cs
+++ b/Solutions/Menes.Specs/Fakes/ExceptionDetail.cs
@@ -15,7 +15,7 @@
     {
         public ExceptionDetail(
             Exception x,
-            AdditionalInstrumentationDetail additionalDetail,
+            AdditionalInstrumentationDetail? additionalDetail,
             OperationDetail operationInProgressAtTime)
         {
             this.Exception = x;
@@ -32,7 +32,7 @@
         /// Gets the additional instrumentation detail (if any) passed to the call to
         /// <see cref="IExceptionsInstrumentation.ReportException(Exception, AdditionalInstrumentationDetail)"/>.
         /// </summary>
-        public AdditionalInstrumentationDetail AdditionalDetail { get; }
+        public AdditionalInstrumentationDetail? AdditionalDetail { get; }
 
         /// <summary>
         /// Gets the <see cref="OperationDetail"/> that was in progress at the instant this exception was reported.

--- a/Solutions/Menes.Specs/Fakes/FakeInstrumentationProvider.cs
+++ b/Solutions/Menes.Specs/Fakes/FakeInstrumentationProvider.cs
@@ -29,7 +29,7 @@ namespace Menes.Specs.Fakes
         public IReadOnlyList<ExceptionDetail> Exceptions => this.exceptions;
 
         /// <inheritdoc/>
-        public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail additionalDetail = null)
+        public IOperationInstance StartOperation(string name, AdditionalInstrumentationDetail? additionalDetail = null)
         {
             var result = new OperationDetail(
                 name,
@@ -45,7 +45,7 @@ namespace Menes.Specs.Fakes
         }
 
         /// <inheritdoc/>
-        public void ReportException(Exception x, AdditionalInstrumentationDetail additionalDetail = null)
+        public void ReportException(Exception x, AdditionalInstrumentationDetail? additionalDetail = null)
         {
             this.exceptions.Add(new ExceptionDetail(x, additionalDetail, this.operationsInProgress.Peek()));
         }

--- a/Solutions/Menes.Specs/Fakes/OperationDetail.cs
+++ b/Solutions/Menes.Specs/Fakes/OperationDetail.cs
@@ -24,7 +24,7 @@ namespace Menes.Specs.Fakes
 
         public OperationDetail(
             string name,
-            AdditionalInstrumentationDetail additionalDetail,
+            AdditionalInstrumentationDetail? additionalDetail,
             Action<OperationDetail> onDisposed)
         {
             this.Name = name;
@@ -41,7 +41,7 @@ namespace Menes.Specs.Fakes
         /// Gets the additional instrumentation detail (if any) passed to the call to
         /// <see cref="IOperationsInstrumentation.StartOperation(string, AdditionalInstrumentationDetail)"/>.
         /// </summary>
-        public AdditionalInstrumentationDetail AdditionalDetail { get; }
+        public AdditionalInstrumentationDetail? AdditionalDetail { get; }
 
         /// <summary>
         /// Gets a list of any further instrumentation detail provided by calls to

--- a/Solutions/Menes.Specs/Features/HalDocument{T}.feature
+++ b/Solutions/Menes.Specs/Features/HalDocument{T}.feature
@@ -12,3 +12,14 @@ Scenario: Serializing a HAL document with a domain class
 	Then the properties of the domain class should be serialized as top level properties in the JSON
 	Then the _embedded collection should be serialized as a top level property of the JSON
 	Then the _links collection should be serialized as a top level property of the JSON
+
+Scenario: Round tripping a HAL document with a domain class
+	Given I have a domain class
+	And I have created an instance of HalDocument{T} from the domain class
+	And I add a link to the HalDocument{T}
+	And I add an embedded resource to the HalDocument{T}
+	When I serialize it to JSON
+	And I deserialize the JSON back to a HalDocument
+	Then the properties of the original document should be present in the deserialized document
+	Then the _embedded collection should be present in the deserialized document
+	Then the _links collection should be present in the deserialized document

--- a/Solutions/Menes.Specs/Features/HalDocument{T}.feature.cs
+++ b/Solutions/Menes.Specs/Features/HalDocument{T}.feature.cs
@@ -132,6 +132,64 @@ this.ScenarioInitialize(scenarioInfo);
             }
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Round tripping a HAL document with a domain class")]
+        public virtual void RoundTrippingAHALDocumentWithADomainClass()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Round tripping a HAL document with a domain class", null, ((string[])(null)));
+#line 16
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 17
+ testRunner.Given("I have a domain class", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 18
+ testRunner.And("I have created an instance of HalDocument{T} from the domain class", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 19
+ testRunner.And("I add a link to the HalDocument{T}", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 20
+ testRunner.And("I add an embedded resource to the HalDocument{T}", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 21
+ testRunner.When("I serialize it to JSON", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 22
+ testRunner.And("I deserialize the JSON back to a HalDocument", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 23
+ testRunner.Then("the properties of the original document should be present in the deserialized doc" +
+                        "ument", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 24
+ testRunner.Then("the _embedded collection should be present in the deserialized document", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 25
+ testRunner.Then("the _links collection should be present in the deserialized document", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/Solutions/Menes.Specs/Menes.Specs.csproj
+++ b/Solutions/Menes.Specs/Menes.Specs.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <RootNamespace>Menes.Specs</RootNamespace>
   </PropertyGroup>

--- a/Solutions/Menes.Specs/Steps/AccessControlPolicySteps.cs
+++ b/Solutions/Menes.Specs/Steps/AccessControlPolicySteps.cs
@@ -26,10 +26,10 @@ namespace Menes.Specs.Steps
     [Binding]
     public class AccessControlPolicySteps
     {
-        private List<(Mock<IOpenApiAccessControlPolicy> policy, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion)> policies;
-        private ClaimsPrincipal claimsPrincipal;
-        private string tenantId;
-        private Task<IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> checkResultTask;
+        private List<(Mock<IOpenApiAccessControlPolicy> policy, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion)>? policies;
+        private ClaimsPrincipal? claimsPrincipal;
+        private string? tenantId;
+        private Task<IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>>? checkResultTask;
 
         [Given("I have configured (.*) access control policies")]
         [Given("I have configured (.*) access control policy")]
@@ -43,7 +43,7 @@ namespace Menes.Specs.Steps
                     var args = new CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>>();
                     mock.Setup(m => m.ShouldAllowAsync(It.IsAny<IOpenApiContext>(), It.IsAny<AccessCheckOperationDescriptor[]>()))
                         .Returns((IOpenApiContext context, AccessCheckOperationDescriptor[] requests)
-                            => args.GetTask(new ShouldAllowArgs { Context = context, Requests = requests }));
+                            => args.GetTask(new ShouldAllowArgs(requests, context)));
 
                     return (mock, args);
                 })
@@ -74,7 +74,7 @@ namespace Menes.Specs.Steps
         public void WhenPolicyBlocksAccessWithoutExplanation(int policyIndex)
         {
             var result = new Dictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>();
-            CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion = this.policies[policyIndex].completion;
+            CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion = this.policies![policyIndex].completion;
             result.Add(completion.Arguments[0].Requests[0], new AccessControlPolicyResult(AccessControlPolicyResultType.NotAllowed));
             completion.SupplyResult(result);
         }
@@ -83,7 +83,7 @@ namespace Menes.Specs.Steps
         public void WhenPolicyBlocksAccessWithExplanation(int policyIndex, string explanation)
         {
             var result = new Dictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>();
-            CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion = this.policies[policyIndex].completion;
+            CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion = this.policies![policyIndex].completion;
             result.Add(completion.Arguments[0].Requests[0], new AccessControlPolicyResult(AccessControlPolicyResultType.NotAllowed, explanation));
             completion.SupplyResult(result);
         }
@@ -92,7 +92,7 @@ namespace Menes.Specs.Steps
         public void WhenPolicyAllowsAccess(int policyIndex)
         {
             var result = new Dictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>();
-            CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion = this.policies[policyIndex].completion;
+            CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion = this.policies![policyIndex].completion;
             result.Add(completion.Arguments[0].Requests[0], new AccessControlPolicyResult(AccessControlPolicyResultType.Allowed));
             completion.SupplyResult(result);
         }
@@ -100,7 +100,7 @@ namespace Menes.Specs.Steps
         [Then("each policy should receive a path of '(.*)'")]
         public void ThenEachPolicyShouldReceiveAPathOf(string path)
         {
-            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies)
+            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies!)
             {
                 Assert.AreEqual(path, completion.Arguments[0].Requests[0].Path);
             }
@@ -109,7 +109,7 @@ namespace Menes.Specs.Steps
         [Then("each policy should receive an operationId of '(.*)'")]
         public void ThenEachPolicyShouldReceiveAnOperationIdOf(string operationId)
         {
-            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies)
+            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies!)
             {
                 Assert.AreEqual(operationId, completion.Arguments[0].Requests[0].OperationId);
             }
@@ -118,7 +118,7 @@ namespace Menes.Specs.Steps
         [Then("each policy should receive an HttpMethod of '(.*)'")]
         public void ThenEachPolicyShouldReceiveAnHttpMethodOf(string method)
         {
-            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies)
+            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies!)
             {
                 Assert.AreEqual(method, completion.Arguments[0].Requests[0].Method);
             }
@@ -127,7 +127,7 @@ namespace Menes.Specs.Steps
         [Then("each policy should receive the ClaimsPrincipal attached to the context")]
         public void ThenEachPolicyShouldReceiveTheClaimsPrincipalAttachedToTheContext()
         {
-            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies)
+            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies!)
             {
                 Assert.AreSame(this.claimsPrincipal, completion.Arguments[0].Context.CurrentPrincipal);
             }
@@ -136,7 +136,7 @@ namespace Menes.Specs.Steps
         [Then("each policy should receive the Tenant attached to the context")]
         public void ThenEachPolicyShouldReceiveTheTenantAttachedToTheContext()
         {
-            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies)
+            foreach ((Mock<IOpenApiAccessControlPolicy> _, CompletionSourceWithArgs<ShouldAllowArgs, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> completion) in this.policies!)
             {
                 Assert.AreSame(this.tenantId, completion.Arguments[0].Context.CurrentTenantId);
             }
@@ -172,9 +172,17 @@ namespace Menes.Specs.Steps
 
         private class ShouldAllowArgs
         {
-            public AccessCheckOperationDescriptor[] Requests { get; set; }
+            public ShouldAllowArgs(
+                AccessCheckOperationDescriptor[] requests,
+                IOpenApiContext context)
+            {
+                this.Requests = requests;
+                this.Context = context;
+            }
 
-            public IOpenApiContext Context { get; set; }
+            public AccessCheckOperationDescriptor[] Requests { get; }
+
+            public IOpenApiContext Context { get; }
         }
     }
 }

--- a/Solutions/Menes.Specs/Steps/CommonInstrumentationSteps.cs
+++ b/Solutions/Menes.Specs/Steps/CommonInstrumentationSteps.cs
@@ -26,7 +26,7 @@ namespace Menes.Specs.Steps
             var template = new OpenApiOperationPathTemplate(
                 new OpenApiOperation { OperationId = operationId },
                 new OpenApiPathTemplate(path, new OpenApiPathItem()));
-            this.InvokerContext.OperationInvocationTask = this.Invoker.InvokeAsync(method, path, null, template, new Mock<IOpenApiContext>().Object);
+            this.InvokerContext.OperationInvocationTask = this.Invoker.InvokeAsync(method, path, new object(), template, new Mock<IOpenApiContext>().Object);
         }
 
         [When("the operation invoker has been invoked")]

--- a/Solutions/Menes.Specs/Steps/CommonSteps.cs
+++ b/Solutions/Menes.Specs/Steps/CommonSteps.cs
@@ -21,8 +21,8 @@ namespace Menes.Specs.Steps
         [Given("I have an object called '(.*)' of type '(.*)'")]
         public void GivenIHaveAnObjectCalledOfType(string objectName, string typeName, Table properties)
         {
-            var targetType = Type.GetType(typeName);
-            object data = properties.CreateInstance(() => Activator.CreateInstance(targetType));
+            Type targetType = Type.GetType(typeName) ?? throw new InvalidOperationException($"Unable to get type info for {typeName}");
+            object data = properties.CreateInstance(() => Activator.CreateInstance(targetType)) ?? throw new InvalidOperationException($"Unable to create instance of {typeName}");
             this.scenarioContext.Set(data, objectName);
         }
     }

--- a/Solutions/Menes.Specs/Steps/ExceptionInstrumentationSteps.cs
+++ b/Solutions/Menes.Specs/Steps/ExceptionInstrumentationSteps.cs
@@ -9,7 +9,7 @@
     [Binding]
     public class ExceptionInstrumentationSteps : InstrumentationStepsBase
     {
-        private Exception operationException;
+        private Exception? operationException;
 
         public ExceptionInstrumentationSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)

--- a/Solutions/Menes.Specs/Steps/ExemptOperationIdsAccessPolicySteps.cs
+++ b/Solutions/Menes.Specs/Steps/ExemptOperationIdsAccessPolicySteps.cs
@@ -20,8 +20,8 @@ namespace Menes.Specs.Steps
     [Binding]
     public class ExemptOperationIdsAccessPolicySteps
     {
-        private ExemptOperationIdsAccessPolicy policy;
-        private IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult> result;
+        private ExemptOperationIdsAccessPolicy? policy;
+        private IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>? result;
 
         [Given("I have a policy that exempts ids '(.*)' and '(.*)'")]
         public void GivenIHaveAPolicyThatExemptsIdsAnd(string opId1, string opId2)
@@ -32,7 +32,7 @@ namespace Menes.Specs.Steps
         [When("I evaluate the exemption policy with an operation id of '(.*)'")]
         public async System.Threading.Tasks.Task WhenIEvaluateTheExemptionPolicyWithAnOperationIdOfAsync(string operationId)
         {
-            this.result = await this.policy.ShouldAllowAsync(
+            this.result = await this.policy!.ShouldAllowAsync(
                 new SimpleOpenApiContext {  CurrentPrincipal = new ClaimsPrincipal(), CurrentTenantId = Guid.NewGuid().ToString() },
                 new AccessCheckOperationDescriptor("/a/path", operationId, "GET"))
                 .WithTimeout()
@@ -42,13 +42,13 @@ namespace Menes.Specs.Steps
         [Then("the policy should allow the operation")]
         public void ThenThePolicyShouldAllowTheOperation()
         {
-            Assert.IsTrue(this.result.Values.First().Allow);
+            Assert.IsTrue(this.result!.Values.First().Allow);
         }
 
         [Then("the policy should deny the operation")]
         public void ThenThePolicyShouldDenyTheOperation()
         {
-            Assert.IsFalse(this.result.Values.First().Allow);
+            Assert.IsFalse(this.result!.Values.First().Allow);
         }
     }
 }

--- a/Solutions/Menes.Specs/Steps/HalDocumentSteps.cs
+++ b/Solutions/Menes.Specs/Steps/HalDocumentSteps.cs
@@ -7,6 +7,7 @@
 
 namespace Menes.Specs.Steps
 {
+    using System.Linq;
     using Corvus.Extensions.Json;
     using Corvus.SpecFlow.Extensions;
     using Menes.Hal;
@@ -62,6 +63,18 @@ namespace Menes.Specs.Steps
             this.scenarioContext.Set(result);
         }
 
+        [When("I deserialize the JSON back to a HalDocument")]
+        public void WhenIDeserializeTheJSONBackToAHalDocument()
+        {
+            JObject previouslySerializedHalDocument = this.scenarioContext.Get<JObject>();
+
+            IJsonSerializerSettingsProvider serializerSettingsProvider = ContainerBindings.GetServiceProvider(this.scenarioContext).GetRequiredService<IJsonSerializerSettingsProvider>();
+            var serializer = JsonSerializer.Create(serializerSettingsProvider.Instance);
+            HalDocument result = previouslySerializedHalDocument.ToObject<HalDocument>(serializer);
+
+            this.scenarioContext.Set(result);
+        }
+
         [Given(@"I add a link to the HalDocument\{T}")]
         public void GivenIAddALinkToTheHalDocumentT()
         {
@@ -92,6 +105,18 @@ namespace Menes.Specs.Steps
             Assert.AreEqual(dto.Property3, result["property3"].Value<decimal>());
         }
 
+        [Then("the properties of the original document should be present in the deserialized document")]
+        public void ThenThePropertiesOfTheOriginalDocumentShouldBePresentInTheDeserializedDocument()
+        {
+            HalDocument result = this.scenarioContext.Get<HalDocument>();
+            TestDomainClass dtoIn = this.scenarioContext.Get<TestDomainClass>();
+            Assert.IsTrue(result.TryGetProperties(out TestDomainClass dtoOut));
+
+            Assert.AreEqual(dtoIn.Property1, dtoOut.Property1);
+            Assert.AreEqual(dtoIn.Property2, dtoOut.Property2);
+            Assert.AreEqual(dtoIn.Property3, dtoOut.Property3);
+        }
+
         [Then("the _embedded collection should be serialized as a top level property of the JSON")]
         public void ThenThe_EmbeddedCollectionShouldBeSerializedAsATopLevelPropertyOfTheJSON()
         {
@@ -99,11 +124,29 @@ namespace Menes.Specs.Steps
             Assert.NotNull(result["_embedded"]);
         }
 
+        [Then("the _embedded collection should be present in the deserialized document")]
+        public void ThenThe_EmbeddedCollectionShouldBePresentInTheDeserializedDocument()
+        {
+            HalDocument result = this.scenarioContext.Get<HalDocument>();
+            Assert.AreEqual(1, result.EmbeddedResources.Count());
+        }
+
         [Then("the _links collection should be serialized as a top level property of the JSON")]
         public void ThenThe_LinksCollectionShouldBeSerializedAsATopLevelPropertyOfTheJSON()
         {
             JObject result = this.scenarioContext.Get<JObject>();
             Assert.NotNull(result["_links"]);
+        }
+
+        [Then("the _links collection should be present in the deserialized document")]
+        public void ThenThe_LinksCollectionShouldBePresentInTheDeserializedDocument()
+        {
+            HalDocument result = this.scenarioContext.Get<HalDocument>();
+            Assert.AreEqual(1, result.Links.Count());
+
+            WebLink link = result.GetLinksForRelation("somrel").Single();
+
+            Assert.AreEqual("http://marain.io/examples/link", link.Href);
         }
 
         private class TestDomainClass

--- a/Solutions/Menes.Specs/Steps/HalDocumentSteps.cs
+++ b/Solutions/Menes.Specs/Steps/HalDocumentSteps.cs
@@ -110,9 +110,9 @@ namespace Menes.Specs.Steps
         {
             HalDocument result = this.scenarioContext.Get<HalDocument>();
             TestDomainClass dtoIn = this.scenarioContext.Get<TestDomainClass>();
-            Assert.IsTrue(result.TryGetProperties(out TestDomainClass dtoOut));
+            Assert.IsTrue(result.TryGetProperties(out TestDomainClass? dtoOut));
 
-            Assert.AreEqual(dtoIn.Property1, dtoOut.Property1);
+            Assert.AreEqual(dtoIn.Property1, dtoOut!.Property1);
             Assert.AreEqual(dtoIn.Property2, dtoOut.Property2);
             Assert.AreEqual(dtoIn.Property3, dtoOut.Property3);
         }
@@ -153,7 +153,7 @@ namespace Menes.Specs.Steps
         {
             public int Property1 { get; set; }
 
-            public string Property2 { get; set; }
+            public string? Property2 { get; set; }
 
             public decimal Property3 { get; set; }
         }

--- a/Solutions/Menes.Specs/Steps/LinkCollectionExtensionsSteps.cs
+++ b/Solutions/Menes.Specs/Steps/LinkCollectionExtensionsSteps.cs
@@ -27,7 +27,7 @@ namespace Menes.Specs.Steps
         {
             var link = new OpenApiWebLink("op", "l", OperationType.Get);
             this.resolver
-                .Setup(r => r.ResolveByOwnerAndRelationType(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<(string, object)[]>()))
+                .Setup(r => r.ResolveByOwnerAndRelationType(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<(string, object?)[]>()))
                 .Returns(link);
             this.scenarioContext.Set(link, linkName);
         }
@@ -37,7 +37,7 @@ namespace Menes.Specs.Steps
         {
             var link = new OpenApiWebLink("op", "l", OperationType.Get);
             this.resolver
-                .Setup(r => r.ResolveByOwnerAndRelationTypeAndContext(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<(string, object)[]>()))
+                .Setup(r => r.ResolveByOwnerAndRelationTypeAndContext(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<(string, object?)[]>()))
                 .Returns(link);
             this.scenarioContext.Set(link, linkName);
         }
@@ -47,7 +47,7 @@ namespace Menes.Specs.Steps
         {
             var link = new OpenApiWebLink("op", "l", OperationType.Get);
             this.resolver
-                .Setup(r => r.ResolveByOperationIdAndRelationType(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<(string, object)[]>()))
+                .Setup(r => r.ResolveByOperationIdAndRelationType(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<(string, object?)[]>()))
                 .Returns(link);
             this.scenarioContext.Set(link, linkName);
         }
@@ -77,7 +77,7 @@ namespace Menes.Specs.Steps
         {
             object target = this.scenarioContext.Get<object>(objectName);
             this.resolver
-                .Verify(r => r.ResolveByOwnerAndRelationType(target, relation, It.IsAny<(string, object)[]>()));
+                .Verify(r => r.ResolveByOwnerAndRelationType(target, relation, It.IsAny<(string, object?)[]>()));
         }
 
         [Then("the link resolver should have been asked to resolve for the owner '(.*)', the relation '(.*)', and the context '(.*)'")]
@@ -85,14 +85,14 @@ namespace Menes.Specs.Steps
         {
             object target = this.scenarioContext.Get<object>(objectName);
             this.resolver
-                .Verify(r => r.ResolveByOwnerAndRelationTypeAndContext(target, relation, context, It.IsAny<(string, object)[]>()));
+                .Verify(r => r.ResolveByOwnerAndRelationTypeAndContext(target, relation, context, It.IsAny<(string, object?)[]>()));
         }
 
         [Then("the link resolver should have been asked to resolve for the operation '(.*)' and the relation '(.*)'")]
         public void ThenTheLinkResolverShouldHaveBeenAskedToResolveForTheOperationAndTheRelation(string operationId, string relation)
         {
             this.resolver
-                .Verify(r => r.ResolveByOperationIdAndRelationType(operationId, relation, It.IsAny<(string, object)[]>()));
+                .Verify(r => r.ResolveByOperationIdAndRelationType(operationId, relation, It.IsAny<(string, object?)[]>()));
         }
 
         [Then("the link '(.*)' should have been added to the link collection with relation '(.*)'")]

--- a/Solutions/Menes.Specs/Steps/OpenApiHostingServiceCollectionExtensionsSteps.cs
+++ b/Solutions/Menes.Specs/Steps/OpenApiHostingServiceCollectionExtensionsSteps.cs
@@ -144,7 +144,7 @@ namespace Menes.Specs.Steps
             // The only way to tell if it's been mapped without reflecting into the guts of the mapper is to try and register
             // a new mapper for the given type/status code... even with this we need a little bit of reflection to invoke the
             // method.
-            var type = Type.GetType(exceptionType);
+            Type type = Type.GetType(exceptionType) ?? throw new InvalidOperationException($"Unable to find type {exceptionType}");
             MethodInfo mapMethod = exceptionMapper
                 .GetType()
                 .GetMethods()
@@ -154,7 +154,7 @@ namespace Menes.Specs.Steps
 
             try
             {
-                createdMapMethod.Invoke(exceptionMapper, new object[] { statusCode, null });
+                createdMapMethod.Invoke(exceptionMapper, new object?[] { statusCode, null });
 
                 Assert.Fail($"Exception of type '{exceptionType}' was not registered");
             }
@@ -197,6 +197,7 @@ namespace Menes.Specs.Steps
         }
 
         private void AssertServiceIsAvailableFromServiceProvider<TService, TExpectedConcreteType>()
+            where TService : notnull
         {
             TService[] services = this.scenarioContext.Get<ServiceProvider>().GetServices<TService>().ToArray();
 

--- a/Solutions/Menes.Specs/Steps/OpenApiMisconfigurationDetectionSteps.cs
+++ b/Solutions/Menes.Specs/Steps/OpenApiMisconfigurationDetectionSteps.cs
@@ -24,9 +24,9 @@ namespace Menes.Specs.Steps
     [Binding]
     public class OpenApiMisconfigurationDetectionSteps
     {
-        private OpenApiOperation operation;
-        private OpenApiDocument document;
-        private Exception exception;
+        private OpenApiOperation? operation;
+        private OpenApiDocument? document;
+        private Exception? exception;
         private readonly ScenarioContext scenarioContext;
 
         public OpenApiMisconfigurationDetectionSteps(ScenarioContext scenarioContext)
@@ -102,7 +102,7 @@ namespace Menes.Specs.Steps
                 var outputBuilder = new PocoActionResultOutputBuilder(
                     Enumerable.Empty<IOpenApiConverter>(),
                     ContainerBindings.GetServiceProvider(this.scenarioContext).GetRequiredService<ILogger<PocoActionResultOutputBuilder>>());
-                outputBuilder.CanBuildOutput(new object(), this.operation);
+                outputBuilder.CanBuildOutput(new object(), this.operation!);
             }
             catch (Exception x)
             {
@@ -132,7 +132,7 @@ namespace Menes.Specs.Steps
             try
             {
                 var exceptionHandler = new OpenApiExceptionMapper(ContainerBindings.GetServiceProvider(this.scenarioContext), new Mock<ILogger<OpenApiExceptionMapper>>().Object);
-                exceptionHandler.GetResponse(new InvalidOperationException(), this.operation);
+                exceptionHandler.GetResponse(new InvalidOperationException(), this.operation!);
             }
             catch (Exception x)
             {
@@ -147,7 +147,7 @@ namespace Menes.Specs.Steps
             var doc = new OpenApiDocumentProvider(new Mock<ILogger<OpenApiDocumentProvider>>().Object);
             try
             {
-                doc.Add(this.document);
+                doc.Add(this.document!);
             }
             catch (Exception x)
             {

--- a/Solutions/Menes.Specs/Steps/OpenApiWebLinkResolverSteps.cs
+++ b/Solutions/Menes.Specs/Steps/OpenApiWebLinkResolverSteps.cs
@@ -48,12 +48,12 @@ namespace Menes.Specs.Steps
         public void GivenIHaveMappedLinkRelationsByType(Table table)
         {
             var mapper = new OpenApiLinkOperationMapper();
-            MethodInfo genericMapMethod = typeof(OpenApiLinkOperationMapper).GetMethod(nameof(IOpenApiLinkOperationMap.MapByContentTypeAndRelationTypeAndOperationId), new[] { typeof(string), typeof(string) });
+            MethodInfo genericMapMethod = typeof(OpenApiLinkOperationMapper).GetMethod(nameof(IOpenApiLinkOperationMap.MapByContentTypeAndRelationTypeAndOperationId), new[] { typeof(string), typeof(string) }) ?? throw new InvalidOperationException($"Unable to get method info for {nameof(IOpenApiLinkOperationMap.MapByContentTypeAndRelationTypeAndOperationId)}");
             IEnumerable<(string RelationName, string TargetType, string OperationId)> mappings = table.CreateSet<(string RelationName, string TargetType, string OperationId)>();
 
             foreach ((string RelationName, string TargetType, string OperationId) in mappings)
             {
-                var targetType = Type.GetType(TargetType);
+                Type targetType = Type.GetType(TargetType) ?? throw new InvalidOperationException($"Unable to get type info for {TargetType}");
                 MethodInfo mapMethod = genericMapMethod.MakeGenericMethod(targetType);
                 mapMethod.Invoke(mapper, new[] { RelationName, OperationId });
             }

--- a/Solutions/Menes.Specs/Steps/OpenApiWebLinkResolverSteps.cs
+++ b/Solutions/Menes.Specs/Steps/OpenApiWebLinkResolverSteps.cs
@@ -79,10 +79,10 @@ namespace Menes.Specs.Steps
         public void WhenIResolveTheLinkRelationForObjectWithParameters(string relationName, string objectName, Table parameterTable)
         {
             object target = this.scenarioContext.Get<object>(objectName);
-            (string Key, string Value)[] parameters = parameterTable.CreateSet<(string Key, string Value)>().ToArray();
+            (string Key, string? Value)[] parameters = parameterTable.CreateSet<(string Key, string? Value)>().ToArray();
 
             var resolver = new OpenApiWebLinkResolver(this.scenarioContext.Get<IOpenApiDocumentProvider>(), this.scenarioContext.Get<IOpenApiLinkOperationMapper>());
-            OpenApiWebLink result = resolver.ResolveByOwnerAndRelationType(target, relationName, parameters.Select(x => (x.Key, (object)x.Value)).ToArray());
+            OpenApiWebLink result = resolver.ResolveByOwnerAndRelationType(target, relationName, parameters.Select(x => (x.Key, (object?)x.Value)).ToArray());
 
             this.scenarioContext.Set(result);
         }

--- a/Solutions/Menes.Specs/Steps/OperationInstrumentationSteps.cs
+++ b/Solutions/Menes.Specs/Steps/OperationInstrumentationSteps.cs
@@ -21,7 +21,7 @@ namespace Menes.Specs.Steps
         public async Task WhenTheOperationCompletes()
         {
             this.InvokerContext.OperationCompletionSource.Complete();
-            await this.InvokerContext.OperationInvocationTask.ConfigureAwait(false);
+            await this.InvokerContext.OperationInvocationTask!.ConfigureAwait(false);
         }
 
         [Then("instrumentation should have already reported the request by the time the operation implementation is invoked")]

--- a/Solutions/Menes.Specs/Steps/TestClasses/MappingContext.cs
+++ b/Solutions/Menes.Specs/Steps/TestClasses/MappingContext.cs
@@ -6,7 +6,7 @@ namespace Menes.Specs.Steps.TestClasses
 {
     public class MappingContext
     {
-        public string ContextProperty1 { get; set; }
+        public string? ContextProperty1 { get; set; }
 
         public int ContextProperty2 { get; set; }
     }

--- a/Solutions/Menes.Specs/Steps/TestClasses/OperationInvokerTestContext.cs
+++ b/Solutions/Menes.Specs/Steps/TestClasses/OperationInvokerTestContext.cs
@@ -23,13 +23,13 @@ namespace Menes.Specs.Steps.TestClasses
         /// Gets an object enabling the calls to the <see cref="IOpenApiAccessChecker"/> to be inspected and its
         /// responses determined. This is only available if you call <see cref="UseManualAccessChecks"/>.
         /// </summary>
-        public CompletionSourceWithArgs<CheckAccessArguments, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>> AccessCheckCalls { get; private set; }
+        public CompletionSourceWithArgs<CheckAccessArguments, IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>>? AccessCheckCalls { get; private set; }
         public Mock<IOpenApiServiceOperationLocator> OperationLocator { get; } = new Mock<IOpenApiServiceOperationLocator>();
         public Mock<IOpenApiExceptionMapper> ExceptionMapper { get; } = new Mock<IOpenApiExceptionMapper>();
         public Mock<IOpenApiResultBuilder<object>> ResultBuilder { get; } = new Mock<IOpenApiResultBuilder<object>>();
         public Mock<IOpenApiParameterBuilder<object>> ParameterBuilder { get; } = new Mock<IOpenApiParameterBuilder<object>>();
         public CompletionSource OperationCompletionSource { get; } = new CompletionSource();
-        public Task OperationInvocationTask { get; set; }
+        public Task? OperationInvocationTask { get; set; }
         public int ReportedOperationCountWhenOperationBodyInvoked { get; set; }
 
         public static void AddServices(IServiceCollection services)
@@ -57,6 +57,14 @@ namespace Menes.Specs.Steps.TestClasses
 
         public class CheckAccessArguments
         {
+            public CheckAccessArguments(
+                IOpenApiContext context,
+                AccessCheckOperationDescriptor[] requests)
+            {
+                this.Context = context;
+                this.Requests = requests;
+            }
+
             public IOpenApiContext Context { get; set; }
 
             public AccessCheckOperationDescriptor[] Requests { get; set; }
@@ -78,7 +86,7 @@ namespace Menes.Specs.Steps.TestClasses
             {
                 return this.context.AccessCheckCalls == null
                     ? Task.FromResult<IDictionary<AccessCheckOperationDescriptor, AccessControlPolicyResult>>(descriptors.ToDictionary(d => d, __ => Allowed))
-                    : this.context.AccessCheckCalls.GetTask(new CheckAccessArguments { Context = context, Requests = descriptors });
+                    : this.context.AccessCheckCalls.GetTask(new CheckAccessArguments(context, descriptors));
             }
         }
     }

--- a/Solutions/Menes.Specs/Steps/TestClasses/Pet.cs
+++ b/Solutions/Menes.Specs/Steps/TestClasses/Pet.cs
@@ -22,12 +22,12 @@ namespace Menes.Specs.Steps.TestClasses
         /// <summary>
         /// Gets or sets the name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = "The Great Mysterio";
 
         /// <summary>
         /// Gets or sets the tag.
         /// </summary>
-        public string Tag { get; set; }
+        public string Tag { get; set; } = "Magic Cat";
 
         /// <summary>
         /// Gets the content type of this pet.

--- a/Solutions/Menes.Specs/Steps/TestClasses/PetHalDocumentMapper.cs
+++ b/Solutions/Menes.Specs/Steps/TestClasses/PetHalDocumentMapper.cs
@@ -4,6 +4,7 @@
 
 namespace Menes.Specs.Steps.TestClasses
 {
+    using System;
     using Menes.Hal;
 
     public class PetHalDocumentMapper : IHalDocumentMapper<Pet>
@@ -17,7 +18,7 @@ namespace Menes.Specs.Steps.TestClasses
 
         public HalDocument Map(Pet resource)
         {
-            return null;
+            throw new NotSupportedException();
         }
     }
 }

--- a/Solutions/Menes.Specs/Steps/TestClasses/PetHalDocumentMapperWithContext.cs
+++ b/Solutions/Menes.Specs/Steps/TestClasses/PetHalDocumentMapperWithContext.cs
@@ -4,6 +4,7 @@
 
 namespace Menes.Specs.Steps.TestClasses
 {
+    using System;
     using Menes.Hal;
 
     public class PetHalDocumentMapperWithContext : IHalDocumentMapper<Pet, MappingContext>
@@ -17,7 +18,7 @@ namespace Menes.Specs.Steps.TestClasses
 
         public HalDocument Map(Pet resource, MappingContext context)
         {
-            return null;
+            throw new NotSupportedException();
         }
     }
 }

--- a/docs/adr/0001-menes-exceptions-have-specialized-constructors.md
+++ b/docs/adr/0001-menes-exceptions-have-specialized-constructors.md
@@ -1,0 +1,26 @@
+# Menes exceptions have specialized constructors
+
+## Status
+
+Accepted.
+
+
+## Context
+
+Switching on the C# 8.0 nullable references feature for Menes has revealed some ambiguities around whether certain properties of exceptions are meant to be nullable.
+
+In many cases, the only reason for ambiguity is that we have followed a pattern of defining various "standard constructors", such as default constructors, exception-message-only constructors, and deserializing constructors.
+
+
+## Decision
+
+Menes exceptions will not have any of these standard exceptions except in cases where there are no required properties (e.g., the exception's type tells you everything you need to know).
+
+Properties that always have non-null values in practice will declare this formally by having non-nullable types.
+
+We will remove all deserializing constructors, and remove the `[Serializable]` attribute from all exceptions that have them. This has been motivated by the use of nullable references, because deserializing constructors cause some challenges there, but this is a distinct issue. Menes exceptions are all designed for use within a Menes-based service. Menes is designed to implement service boundaries, and by definition, if we ever attempt to throw a Menes-defined exception across a process boundary, we've made a mistake.
+
+
+## Consequences
+
+Properties on exceptions can accurately reflect whether they can be relied upon to be present by using non-nullable or nullable types. By removing unused "standard" constructors, we avoid having to work around warnings the compiler would generate complaining that non-nullable properties have not been initialized.

--- a/docs/adr/0002-multitargeting-.net-standard-2.0-and-2.1.md
+++ b/docs/adr/0002-multitargeting-.net-standard-2.0-and-2.1.md
@@ -1,0 +1,25 @@
+# Multitargeting .NET Standard 2.0 and 2.1
+
+## Status
+
+Accepted.
+
+## Context
+
+Menes supports C# 8.0's nullable references feature. In most cases, libraries need to use some of the attributes from the `System.Diagnostics.CodeAnalysis` namespace that enable to you provide sufficient information for the compiler's null analysis to do a good job.
+
+These attributes are not available in `netstandard2.0`. However, there is a standard workaround: define your own copies of these attributes and use those. We are using the `Nullable` NuGet package to do this for us. This works nicely, enabling applications targeting older runtimes still to enable nullable references.
+
+The problem is that you don't want to use this workaround unless you have to. Newer versions of .NET Core and .NET Standard have these attributes, so it's just a waste of space to define your own.
+
+## Decision
+
+Menes will target both .NET Standard 2.0 and .NET Standard 2.1. The .NET Standard 2.0 version brings its own copies of the attributes, the .NET Standard 2.1 version relies on the ones built into the framework.
+
+## Consequences
+
+This enables most of the benefits of the nullable references feature to be enjoyed by applications that target older versions of .NET. (They just need to set the language version to C# 8.0 or later, and set `<Nullable>enabled</Nullable>` in their `.csproj` files.) Applications on the latest versions of .NET will not have to pay for the duplicated attributes that enable this because they can use the .NET Standard 2.1 version of the library, which just uses the built-in attributes.
+
+The build of Menes itself benefits from multi-targeting, instead of just targeting .NET Standard 2.0. If we only built for .NET Standard 2.0 (which would work), we would never be building against a version of the .NET libraries that include the full nullable annotations. But because we also target .NET Standard 2.1, we will be built against a version of the libraries that are fully annotated. This may enable the compiler to detect null-related anomalies that would otherwise have been missed.
+
+The downside of this decision is that multi-targeting adds friction. For example, all the tests run twice up on the build server, once for each target, but annoyingly, Visual Studio won't run both sets locally. So if there are scenarios in which a test fails on only one target you might not discover this until after pushing changes. Also, when you multi-target, Visual Studio starts showing two of various things. Everything shows up twice in search results, for example. Also, multi-targeting hits a completely different set of paths through the SDK build infrastructure, which can often cause things to break in unexpected ways. So for these reasons it's generally preferable not to multi-target if you can avoid it.


### PR DESCRIPTION
- Set `<Nullable>enabled</Nullable>` in all `.csproj` files.
- Added annotations (use of `?` and, where applicable, nullability attributes)
- Now multi-targetting so we can use the proper attributes on recent .NET frameworks (using `Nullable` NuGet package for .NET Standard 2.0)
- `HalDocument` deserialization now works (the relevant code was causing nullability warnings; it had no tests, so I wrote some tests first so I could be confident that my modifications hadn't broken anything, only it turned out that deserialization wasn't actually working, so I've now fixed that)

Resolves #35 