### PR TITLE
Update gitversion.yml config

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,4 +2,4 @@ mode: "ContinuousDeployment"
 branches:
   master:
     tag: preview
-    increment: Minor
+    increment: Patch

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,3 +3,4 @@ branches:
   master:
     tag: preview
     increment: Patch
+next-version: 1.1


### PR DESCRIPTION
Set the default increment to patch, and explicitly set the major.minor in next version.

This means that to bump minor or major version, we have to update the gitversion.yml file to show the intent. Otherwise, we bump the version number by patch increment.