### PR TITLE
Execute .feature files for both hosting modes

### DIFF
--- a/Solutions/Menes.PetStore.Specs/Features/CreatePet.feature.multi.cs
+++ b/Solutions/Menes.PetStore.Specs/Features/CreatePet.feature.multi.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="CreatePet.feature.multi.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Features
+{
+    using Menes.PetStore.Specs.Internals;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Adds in multi-form execution.
+    /// </summary>
+    [TestFixtureSource(nameof(FixtureArgs))]
+    public partial class CreatePetFeature : MultiTestHostBase
+    {
+        /// <summary>
+        /// Creates a <see cref="CreatePetFeature"/>.
+        /// </summary>
+        /// <param name="hostType">
+        /// Hosting style to test for.
+        /// </param>
+        public CreatePetFeature(TestHostTypes hostType)
+            : base(hostType)
+        {
+        }
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Features/ExampleUsingStubInMenesService.feature.multi.cs
+++ b/Solutions/Menes.PetStore.Specs/Features/ExampleUsingStubInMenesService.feature.multi.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="ExampleUsingStubInMenesService.feature.multi.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Features
+{
+    using Menes.PetStore.Specs.Internals;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Adds in multi-form execution.
+    /// </summary>
+    [TestFixtureSource(nameof(FixtureArgs))]
+    public partial class ExampleUsingStubInMenesServiceFeature : MultiTestHostBase
+    {
+        /// <summary>
+        /// Creates a <see cref="ExampleUsingStubInMenesServiceFeature"/>.
+        /// </summary>
+        /// <param name="hostType">
+        /// Hosting style to test for.
+        /// </param>
+        public ExampleUsingStubInMenesServiceFeature(TestHostTypes hostType)
+            : base(hostType)
+        {
+        }
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Features/GetPetById.feature.multi.cs
+++ b/Solutions/Menes.PetStore.Specs/Features/GetPetById.feature.multi.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="GetPetById.feature.multi.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Features
+{
+    using Menes.PetStore.Specs.Internals;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Adds in multi-form execution.
+    /// </summary>
+    [TestFixtureSource(nameof(FixtureArgs))]
+    public partial class GetPetByIdFeature : MultiTestHostBase
+    {
+        /// <summary>
+        /// Creates a <see cref="GetPetByIdFeature"/>.
+        /// </summary>
+        /// <param name="hostType">
+        /// Hosting style to test for.
+        /// </param>
+        public GetPetByIdFeature(TestHostTypes hostType)
+            : base(hostType)
+        {
+        }
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Features/ListPets.feature.multi.cs
+++ b/Solutions/Menes.PetStore.Specs/Features/ListPets.feature.multi.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="ListPets.feature.multi.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Features
+{
+    using Menes.PetStore.Specs.Internals;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Adds in multi-form execution.
+    /// </summary>
+    [TestFixtureSource(nameof(FixtureArgs))]
+    public partial class ListPetsFeature : MultiTestHostBase
+    {
+        /// <summary>
+        /// Creates a <see cref="ListPetsFeature"/>.
+        /// </summary>
+        /// <param name="hostType">
+        /// Hosting style to test for.
+        /// </param>
+        public ListPetsFeature(TestHostTypes hostType)
+            : base(hostType)
+        {
+        }
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Internals/AspNetDirectPetStoreStartupTestWrapper.cs
+++ b/Solutions/Menes.PetStore.Specs/Internals/AspNetDirectPetStoreStartupTestWrapper.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="AspNetDirectPetStoreStartupTestWrapper.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Bindings
+{
+    using System;
+
+    using Menes.PetStore.Hosting.AspNetCore.DirectPipeline;
+
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Enables tests to meddle with service collections after the DirectPipeline host's Startup
+    /// class has finished configuring services.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This supports the <c>@useStubServiceImplementation</c> tag. For that to work, we need to
+    /// adjust the service collection after the Startup class has run. This is slightly problematic
+    /// because the ASP.NET host startup code invokes configuration callbacks before it invokes the
+    /// Startup type's configuration method.
+    /// </para>
+    /// <para>
+    /// When tests are running in Functions mode, we actually invoke the Functions configuration
+    /// code ourselves as part of the fakery around reproducing aspects of the Functions host when
+    /// hosting code directly in the test process. So the fact that ASP.NET Core invokes
+    /// configuration callbacks before Startup configuration doesn't matter because ASP.NET Core
+    /// isn't the thing running the Startup type of the code under test.
+    /// </para>
+    /// <para>
+    /// In ASP.NET Core direct pipeline mode, we don't use the mechanisms we use in Functions mode,
+    /// so we need to adapt the existing startup type to be able to inject the code we need at the
+    /// right point.
+    /// </para>
+    /// </remarks>
+    public class AspNetDirectPetStoreStartupTestWrapper
+    {
+        private readonly Action<IServiceCollection> postStartupConfigurationCallback;
+        private readonly Startup hostStartup;
+
+        public AspNetDirectPetStoreStartupTestWrapper(
+            Action<IServiceCollection> postStartupConfigurationCallback)
+        {
+            this.postStartupConfigurationCallback = postStartupConfigurationCallback;
+            this.hostStartup = new Startup();
+        }
+
+        /// <summary>
+        /// Called by ASP.NET Core during DI initialization.
+        /// </summary>
+        /// <param name="services">The DI service collection to initialize.</param>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            this.hostStartup.ConfigureServices(services);
+
+            this.postStartupConfigurationCallback(services);
+        }
+
+        /// <summary>
+        /// Called by ASP.NET Core to enable us to configure the HTTP request pipeline.
+        /// </summary>
+        /// <param name="app">Pipeline builder.</param>
+        /// <param name="env">Host environment information.</param>
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            this.hostStartup.Configure(app, env);
+        }
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Internals/IMultiModeTest.cs
+++ b/Solutions/Menes.PetStore.Specs/Internals/IMultiModeTest.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="IMultiModeTest.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Internals
+{
+    /// <summary>
+    /// Supports executing the same test fixture multiple times in different modes.
+    /// </summary>
+    /// <typeparam name="T">The type used to indicate the mode.</typeparam>
+    internal interface IMultiModeTest<T>
+    {
+        /// <summary>
+        /// Gets the mode in which the test is executing.
+        /// </summary>
+        T TestType { get; }
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Internals/MultiTestHostBase.cs
+++ b/Solutions/Menes.PetStore.Specs/Internals/MultiTestHostBase.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="MultiTestHostBase.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Internals
+{
+    /// <summary>
+    /// Base class for tests that need to run for both Functions emulation and direct ASP.NET
+    /// pipeline hosting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Tests can derive from this and set the following class-level attribute:
+    /// </para>
+    /// <code><![CDATA[
+    /// [TestFixtureSource(nameof(FixtureArgs))]
+    /// ]]></code>
+    /// <para>
+    /// This needs to be specified on each deriving class, because NUnit does not walk up the
+    /// inheritance chain when looking for test fixture sources.
+    /// </para>
+    /// <para>
+    /// Deriving classes should also define a constructor that has the same signature as this
+    /// class's constructor, forwarding the argument on. This, in conjunction with the test
+    /// fixture source attribute, will cause NUnit to run the fixture for this class multiple
+    /// times, once for each of the host types specified in <see cref="FixtureArgs"/>.
+    /// </para>
+    /// <para>
+    /// When using SpecFlow, bindings can detect the mode by casting the reference in
+    /// <c>TestExecutionContext.CurrentContext.TestObject</c> to <see cref="IMultiModeTest{TestHostTypes}"/>
+    /// and then inspecting the <see cref="IMultiModeTest{TestHostTypes>.TestType"/> property.
+    /// </para>
+    /// </remarks>
+    public class MultiTestHostBase : IMultiModeTest<TestHostTypes>
+    {
+        protected static readonly object[] FixtureArgs =
+        {
+            new object[] { TestHostTypes.EmulateFunctionWithActionResult },
+            new object[] { TestHostTypes.AspNetDirectPipeline },
+        };
+
+        /// <summary>
+        /// Creates a <see cref="MultiTestHostBase"/>.
+        /// </summary>
+        /// <param name="testType">
+        /// Hosting style to test for.
+        /// </param>
+        private protected MultiTestHostBase(TestHostTypes testType)
+        {
+            this.TestType = testType;
+        }
+
+        /// <inheritdoc />
+        public TestHostTypes TestType { get; }
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Internals/TestHostTypes.cs
+++ b/Solutions/Menes.PetStore.Specs/Internals/TestHostTypes.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="TestHostTypes.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.PetStore.Specs.Internals
+{
+    /// <summary>
+    /// Host types for which test suites may be executed.
+    /// </summary>
+    /// <remarks>
+    /// Menes supports two modes of ASP.NET Core hosting, and we want to run certain sets of tests
+    /// against each of these. This enumeration type is used to determine which mode a suite is
+    /// being executed for.
+    /// </remarks>
+    public enum TestHostTypes
+    {
+        EmulateFunctionWithActionResult,
+        AspNetDirectPipeline,
+    }
+}

--- a/Solutions/Menes.PetStore.Specs/Menes.PetStore.Specs.csproj
+++ b/Solutions/Menes.PetStore.Specs/Menes.PetStore.Specs.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <!-- Disabling SA1204 because it prioritizes static/non-static over public/non-public, which doesn't fit very well
@@ -22,6 +22,7 @@
     <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.3.5" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Menes.PetStore.Hosting.AspNetCore.DirectPipeline\Menes.PetStore.Hosting.AspNetCore.DirectPipeline.csproj" />
     <ProjectReference Include="..\Menes.PetStore.Hosting.AzureFunctions\Menes.PetStore.Hosting.AzureFunctions.csproj" />
     <ProjectReference Include="..\Menes.Testing.AspNetCoreSelfHosting\Menes.Testing.AspNetCoreSelfHosting.csproj" />
   </ItemGroup>
@@ -30,4 +31,20 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <!--
+  To enable execution of feature files for each hosting mode, we exploit the fact that SpecFlow's
+  NUnit integration generates partial classes. We modify these by adding a constructor and a test
+  fixture source that causes the suite for certain features to run multiple times, once for each
+  hosting type.
+  We put our custom additions to these partial classes in files named FeatureName.feature.multi.cs.
+  The following ItemGroup arranges for these to appear nested inside FeatureName.feature (just like
+  the FeatureName.cs files that SpecFlow generates).
+  -->
+  <ItemGroup>
+    <Compile Update="**\*.feature.multi.cs">
+      <DependentUpon>%(RelativeDir)$([System.String]::Copy('%(Filename)').Replace(".multi", ""))</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/Solutions/Menes.PetStore.Specs/Steps/Steps.cs
+++ b/Solutions/Menes.PetStore.Specs/Steps/Steps.cs
@@ -97,8 +97,8 @@ namespace Menes.PetStore.Specs.Steps
         {
             HttpResponseMessage response = this.scenarioContext.Get<HttpResponseMessage>();
 
-            Assert.IsTrue(response.Headers.TryGetValues(headerName, out IEnumerable<string> values));
-            Assert.IsNotEmpty(values);
+            Assert.IsTrue(response.Headers.TryGetValues(headerName, out IEnumerable<string>? values));
+            Assert.IsNotEmpty(values!);
         }
 
         [Then("the response should not contain the '(.*)' header")]

--- a/Solutions/Menes.Testing.AspNetCoreSelfHosting/Menes/Testing/AspNetCoreSelfHosting/Internal/OpenApiWebHostDirectPipelineStartup.cs
+++ b/Solutions/Menes.Testing.AspNetCoreSelfHosting/Menes/Testing/AspNetCoreSelfHosting/Internal/OpenApiWebHostDirectPipelineStartup.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="OpenApiWebHostDirectPipelineStartup.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Menes.Testing.AspNetCoreSelfHosting.Internal
+{
+    using Menes.Hosting.AspNetCore;
+
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+
+    /// <summary>
+    /// Startup class used with <see cref="IWebHostBuilder"/> to initialise a webhost for tests
+    /// the use ASP.NET direct pipeline hosting.
+    /// </summary>
+    internal class OpenApiWebHostDirectPipelineStartup
+    {
+        /// <summary>
+        /// Configures the function host, adding a catch-all route that then hands off to Menes to process the request.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> to configure.</param>
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseMenesCatchAll();
+        }
+    }
+}

--- a/Solutions/Menes.Testing.AspNetCoreSelfHosting/Menes/Testing/AspNetCoreSelfHosting/OpenApiWebHostManager.cs
+++ b/Solutions/Menes.Testing.AspNetCoreSelfHosting/Menes/Testing/AspNetCoreSelfHosting/OpenApiWebHostManager.cs
@@ -7,7 +7,9 @@ namespace Menes.Testing.AspNetCoreSelfHosting
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+
     using Menes.Testing.AspNetCoreSelfHosting.Internal;
+
     using Microsoft.AspNetCore;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Azure.WebJobs.Hosting;
@@ -21,7 +23,7 @@ namespace Menes.Testing.AspNetCoreSelfHosting
     /// This class allows you to use the same Startup class that's used in an Azure function to run services in memory.
     /// To run the same services in memory as your function, obtain an instance of this class (if you wish to run multiple
     /// services, you can create a single instance of this class to manage all services). Then use the
-    /// <see cref="StartHostAsync"/> method to add services, supplying the Startup class from your function and/or a
+    /// <see cref="StartAspNetHostAsync"/> method to add services, supplying the Startup class from your function and/or a
     /// callback to configure the service collection and the base url (including port number where necessary) that the
     /// endpoints should be made available on.
     /// </para>
@@ -29,7 +31,7 @@ namespace Menes.Testing.AspNetCoreSelfHosting
     /// Note that this assumes you're using an instance method in your function host rather than the older static method
     /// approach. This means that your initialisation will have been moved into a Startup class that implements
     /// <c>IWebJobsStartup</c> or <c>FunctionsStartup</c>; this is the class that should be supplied to
-    /// <see cref="StartHostAsync"/>.
+    /// <see cref="StartAspNetHostAsync"/>.
     /// </para>
     /// <para>
     /// You will normally make this call in a method tagged with either <c>BeforeScenario</c> or <c>BeforeFeature</c>. In the
@@ -44,7 +46,8 @@ namespace Menes.Testing.AspNetCoreSelfHosting
         private readonly List<IWebHost> webHosts = new List<IWebHost>();
 
         /// <summary>
-        /// Starts a new function host using the given Uri and startup class.
+        /// Starts a new in-process host using the given Uri and startup class, with basic emulation of the Azure Functions
+        /// host's request routing..
         /// </summary>
         /// <typeparam name="TFunctionStartup">The type of the startup class. This should be the type of the class from the
         /// function host project that is used to initialise the OpenApi services and dependencies.</typeparam>
@@ -54,21 +57,64 @@ namespace Menes.Testing.AspNetCoreSelfHosting
         /// your startup class has executed. You can use this to swap out services for stubs or fakes.
         /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task StartHostAsync<TFunctionStartup>(
+        public Task StartInProcessFunctionsHostAsync<TFunctionStartup>(
             string baseUrl,
             Action<IServiceCollection>? additionalServiceConfigurationCallback = null)
-            where TFunctionStartup : IWebJobsStartup, new()
-        {
-            return this.StartHostAsync(baseUrl, s =>
-            {
-                // Shim to allow us to invoke the configuration method of the services startup class.
-                var webJobBuilder = new WebJobBuilder(s);
-                var targetStartup = new TFunctionStartup();
-                targetStartup.Configure(webJobBuilder);
+            where TFunctionStartup : class, IWebJobsStartup, new()
+            => this.StartAspNetHostAsync(
+                baseUrl,
+                services =>
+                {
+                    // Shim to allow us to invoke the configuration method of the services startup class.
+                    // (We pass a completely different class in for ASP.NET Core to use as the startup
+                    // class, in order to fake the bits of the Functions host that we need to fake,
+                    // which is why we need to invoke the real startup directly. This also has the
+                    // benefit of enabling us to control the order: it's important that the additional
+                    // configuration callback is invoked after Startup configuration, because that
+                    // callback is used by some tests to replace certain services set up by Startup.)
+                    var webJobBuilder = new WebJobBuilder(services);
+                    var startupInstance = new TFunctionStartup();
+                    startupInstance.Configure(webJobBuilder);
 
-                // Invoke any extra container configuration.
-                additionalServiceConfigurationCallback?.Invoke(s);
-            });
+                    // Invoke any extra container configuration.
+                    additionalServiceConfigurationCallback?.Invoke(services);
+                },
+                webHostBuilder => webHostBuilder.UseStartup<OpenApiWebHostStartup>());
+
+        /// <summary>
+        /// Starts a new in-process host using the given Uri and a pre-instantiated instance of the startup class.
+        /// </summary>
+        /// <typeparam name="TStartup">The type of the startup class. This should be the type of the class from the
+        /// ASP.NET host project that is used to initialise the OpenApi services and dependencies.</typeparam>
+        /// <param name="baseUrl">The url that the function will be exposed on.</param>
+        /// <param name="startupInstance">The instantiated startup class to use.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>
+        /// If you need to run further service configuration that is guaranteed to execute after the Startup
+        /// DI configuration when testing with ASP.NET direct pipeline hosting, use a wrapper startup class
+        /// because that's the only way to ensure that your configuration will run after Startup. (The ASP.NET
+        /// web host startup prefers to run the Startup methods after all other configuration has occurred.)
+        /// </remarks>
+        public Task StartInProcessAspNetHostAsync<TStartup>(
+            string baseUrl,
+            TStartup startupInstance)
+            where TStartup : class
+            => this.StartAspNetHostAsync(
+                baseUrl,
+                services => services.AddSingleton(startupInstance),
+                webHostBuilder => webHostBuilder.UseStartup<TStartup>());
+
+        /// <summary>
+        /// Stops all of the function hosts that were started via <see cref="StartAspNetHostAsync"/>.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task StopAllHostsAsync()
+        {
+            foreach (IWebHost current in this.webHosts)
+            {
+                await current.StopAsync().ConfigureAwait(false);
+                current.Dispose();
+            }
         }
 
         /// <summary>
@@ -78,10 +124,14 @@ namespace Menes.Testing.AspNetCoreSelfHosting
         /// <param name="serviceConfigurationCallback">
         /// A callback that will allow you to configure the <see cref="IServiceCollection"/> for your service.
         /// </param>
+        /// <param name="webHostBuilderCallback">
+        /// A callback that will allow you to configure the <see cref="IWebHostBuilder"/> for your service.
+        /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task StartHostAsync(
+        private Task StartAspNetHostAsync(
             string baseUrl,
-            Action<IServiceCollection> serviceConfigurationCallback)
+            Action<IServiceCollection> serviceConfigurationCallback,
+            Action<IWebHostBuilder> webHostBuilderCallback)
         {
             if (string.IsNullOrEmpty(baseUrl))
             {
@@ -95,7 +145,7 @@ namespace Menes.Testing.AspNetCoreSelfHosting
 
             IWebHostBuilder builder = WebHost.CreateDefaultBuilder();
             builder.UseUrls(baseUrl);
-            builder.UseStartup<OpenApiWebHostStartup>();
+            webHostBuilderCallback(builder);
 
             builder.ConfigureServices(serviceConfigurationCallback);
 
@@ -104,19 +154,6 @@ namespace Menes.Testing.AspNetCoreSelfHosting
             this.webHosts.Add(host);
 
             return host.StartAsync();
-        }
-
-        /// <summary>
-        /// Stops all of the function hosts that were started via <see cref="StartHostAsync"/>.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task StopAllHostsAsync()
-        {
-            foreach (IWebHost current in this.webHosts)
-            {
-                await current.StopAsync().ConfigureAwait(false);
-                current.Dispose();
-            }
         }
     }
 }


### PR DESCRIPTION
This is an experiment in how to run the same tests twice, once for the 'classic' hosting (faking things up to resemble the Azure Functions host, and existing an `IActionResult` result type), and once for the new direct pipeline hosting model.

This exploits NUnit's ability to define parameterised test suites using the `TestFixtureSource` attribute. It requires bit of boilerplate in the form of an additional partial class file for each feature file that wishes to participate, but is otherwise fairly unobtrusive. The least satisfactory aspect of this is that we need to use NUnit's `TestExecutionContext.CurrentContext.TestObject` to retrieve a reference to the current test instance. This seems to be necessary because there doesn't appear to be any way for code we put in that partial class for the generated NUnit test fixture to put things where SpecFlow bindings can see them. It's slightly problematic because that `TestExecutionContext` class, although public, is in an `Internal` namespace.

This, combined with the fact that SpecFlow resolutely insist that if you want this feature (the ability to execute the same set of specs more than one way) you are an idiot, means that the greatest concern with this is that it will all fall apart when either SpecFlow or NUnit changes something in some future update.