### PR TITLE
Make test config available through DI

### DIFF
--- a/Solutions/Menes.Testing.AspNetCoreSelfHosting/Menes/Testing/AspNetCoreSelfHosting/OpenApiWebHostManager.cs
+++ b/Solutions/Menes.Testing.AspNetCoreSelfHosting/Menes/Testing/AspNetCoreSelfHosting/OpenApiWebHostManager.cs
@@ -162,6 +162,7 @@ namespace Menes.Testing.AspNetCoreSelfHosting
                     {
                         Configuration = configuration,
                     };
+                    services.AddSingleton(configuration);
                     startupInstance.Configure(context, webJobBuilder);
 
                     // Invoke any extra container configuration.


### PR DESCRIPTION
The preceding change in which we enabled an IConfiguration to be passed to OpenApiWebHostManager only make that available during DI initialization. It was not available as a service from DI itself - you got the default ASP.NET Core one instead. This makes the same IConfiguration available through both routes.