### PR TITLE
Switched the Swagger endpoint to return OpenApi v3

### DIFF
--- a/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentJsonConverter.cs
+++ b/Solutions/Menes.Abstractions/Menes/Internal/OpenApiDocumentJsonConverter.cs
@@ -47,7 +47,7 @@ namespace Menes.Internal
             var document = (OpenApiDocument)value;
 
             using var stream = new MemoryStream();
-            document.SerializeAsJson(stream, OpenApiSpecVersion.OpenApi2_0);
+            document.SerializeAsJson(stream, OpenApiSpecVersion.OpenApi3_0);
             stream.Seek(0, SeekOrigin.Begin);
 
             using var reader = new StreamReader(stream);


### PR DESCRIPTION
Many of our OpenAPI definitions now use features not supported in OpenApi v2. As such, the documents sometimes get badly mangled (or, at least, are missing various elements) when they are returned via the `/swagger` endpoint that Menes can provide. So this change moves over to v3 serialization.