### PR TITLE
Back out change that adds quotes to values returned by the StringConverter

### DIFF
--- a/Solutions/Menes.Abstractions/Menes/Converters/StringConverter.cs
+++ b/Solutions/Menes.Abstractions/Menes/Converters/StringConverter.cs
@@ -53,7 +53,7 @@ namespace Menes.Converters
 
             this.validator.ValidateAndThrow(result, schema);
 
-            return '"' + result + '"';
+            return result;
         }
     }
 }

--- a/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/OpenApiHttpResponseResult.cs
+++ b/Solutions/Menes.Hosting.AspNetCore/Menes/Internal/OpenApiHttpResponseResult.cs
@@ -317,17 +317,6 @@ namespace Menes.Internal
                         convertedValue = this.ConvertValue(header.Value.Schema, value);
                     }
 
-                    // If the input value was a string, it will have been returned as if it were a serialized JSON element.
-                    // This means it will be quoted, which we don't want for values going in the headers, so we'll get rid
-                    // of the quotes if they are present. In order to ensure any other escaped characters introduced during
-                    // serialization are written correctly, we need to do this by deserializing the data and extracting the
-                    // string value from the resulting JToken.
-                    if (convertedValue.Length > 0 && convertedValue[0] == '"')
-                    {
-                        var tokenValue = JToken.Parse(convertedValue);
-                        convertedValue = tokenValue.ToObject<string>();
-                    }
-
                     httpResponse.Headers.Add(header.Key, new StringValues(convertedValue));
 
                     if (this.logger.IsEnabled(LogLevel.Debug))

--- a/Solutions/Menes.PetStore/Menes/PetStore/PetStore.yaml
+++ b/Solutions/Menes.PetStore/Menes/PetStore/PetStore.yaml
@@ -189,6 +189,10 @@ paths:
             application/hal+json:
               schema:
                 $ref: "#/components/schemas/Pet"
+          headers:
+            ETag:
+              schema:
+                type: string
         '404':
           description: No pet with that ID
         default:

--- a/Solutions/Menes.PetStore/Menes/PetStore/PetStoreService.cs
+++ b/Solutions/Menes.PetStore/Menes/PetStore/PetStoreService.cs
@@ -342,9 +342,13 @@ namespace Menes.PetStore
 
             HalDocument response = await this.petMapper.MapAsync(result).ConfigureAwait(false);
 
-            return this
+            OpenApiResult openApiResponse = this
                 .OkResult(response, "application/hal+json")
                 .WithAuditData(("id", result.Id));
+
+            openApiResponse.Results.Add("ETag", $"\"{result.GetHashCode()}\"");
+
+            return openApiResponse;
         }
     }
 }

--- a/Solutions/Menes.Specs/Features/JsonTypeConversion/DateTimeOutputParsing.feature
+++ b/Solutions/Menes.Specs/Features/JsonTypeConversion/DateTimeOutputParsing.feature
@@ -12,5 +12,5 @@ Scenario Outline: Valid values for simple types
     Then the response body should be '<ExpectedResult>'
 
     Examples:
-        | Value                | ExpectedResult |
-        | 2017-07-21T00:00:00Z | "2017-07-21T00:00:00Z"   |
+        | Value                | ExpectedResult       |
+        | 2017-07-21T00:00:00Z | 2017-07-21T00:00:00Z |


### PR DESCRIPTION
A change was recently added to the `StringConverter` class to return all values in double quotes. This was added to try and make the converters consistent, as the majority of them return valid JSON serialized data.

This caused some issues when writing out headers - discussed in #328 and addressed in #329. However, this fix is not complete; strings that included quotes before being passed through the `StringConverter` - such as ETag values - cannot then be deserialized by the new code in `OpenApiHttpResponseResult`, because their additional special characters have not been correctly escaped according to JSON rules.

Changing the `StringConverter` to process the input using `JsonConvert.SerializeObject`, in the same way as other converters such as the `Integer32Converter` is also not an option as the subsequent call to `OpenApiSchemaValidator.ValidateAndThrow` then fails due to the enclosing quotes being in place already. The current code adds the quotes after the call to `ValidateAndThrow` meaning that it's possible for the output of the `StringConverter` to be invalid according to the schema despite having passed validation because we modify the output after validation is complete.

Right now, I think the best approach is to back out the original change to `StringConverter` so it doesn't add quotes to the result. This also means we can back out the change from #329. We can then revisit the original requirement that introduced this change, but with knowledge of the pitfalls we've encountered so far.