### PR TITLE
Further changes to StringConverter to ensure special characters are properly escaped

### DIFF
--- a/Solutions/Menes.Abstractions/Menes/Converters/StringConverter.cs
+++ b/Solutions/Menes.Abstractions/Menes/Converters/StringConverter.cs
@@ -6,6 +6,8 @@ namespace Menes.Converters
 {
     using Menes.Validation;
     using Microsoft.OpenApi.Models;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// An OpenAPI converter for strings.
@@ -13,14 +15,17 @@ namespace Menes.Converters
     public class StringConverter : IOpenApiConverter
     {
         private readonly OpenApiSchemaValidator validator;
+        private readonly IOpenApiConfiguration configuration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StringConverter"/> class.
         /// </summary>
         /// <param name="validator">The <see cref="OpenApiSchemaValidator"/>.</param>
-        public StringConverter(OpenApiSchemaValidator validator)
+        /// <param name="configuration">The OpenAPI host configuration.</param>
+        public StringConverter(OpenApiSchemaValidator validator, IOpenApiConfiguration configuration)
         {
             this.validator = validator;
+            this.configuration = configuration;
         }
 
         /// <inheritdoc/>
@@ -40,20 +45,11 @@ namespace Menes.Converters
         /// <inheritdoc/>
         public string ConvertTo(object instance, OpenApiSchema schema)
         {
-            string result;
+            string result = JsonConvert.SerializeObject(instance, this.configuration.Formatting, this.configuration.SerializerSettings);
 
-            if (instance is string stringValue)
-            {
-                result = stringValue;
-            }
-            else
-            {
-                result = instance.ToString()!;
-            }
+            this.validator.ValidateAndThrow(JToken.Parse(result), schema);
 
-            this.validator.ValidateAndThrow(result, schema);
-
-            return '"' + result + '"';
+            return result;
         }
     }
 }

--- a/Solutions/Menes.PetStore.Specs/Features/GetPetById.feature
+++ b/Solutions/Menes.PetStore.Specs/Features/GetPetById.feature
@@ -9,6 +9,7 @@ Feature: Get Pet By Id
 Scenario: Request a pet
 	When I request the pet with Id 1
 	Then the response status code should be 'OK'
+	And the response should contain the 'ETag' header
 	And the response object should have a property called '_links.self'
 	And the response object should have a property called 'id'
 	And the response object should have a property called 'name'

--- a/Solutions/Menes.PetStore.Specs/Steps/Steps.cs
+++ b/Solutions/Menes.PetStore.Specs/Steps/Steps.cs
@@ -111,11 +111,14 @@ namespace Menes.PetStore.Specs.Steps
             Assert.IsTrue(response.Headers.TryGetValues(headerName, out IEnumerable<string>? values));
             Assert.IsNotEmpty(values!);
 
-            // Ensure the supplied value is a valid URI
-            string rawLocation = values!.First();
-            string decodedLocation = Uri.UnescapeDataString(rawLocation);
+            if (headerName == "Location")
+            {
+                // Ensure the supplied value is a valid URI
+                string rawLocation = values!.First();
+                string decodedLocation = Uri.UnescapeDataString(rawLocation);
 
-            Assert.IsTrue(Uri.IsWellFormedUriString(decodedLocation, UriKind.RelativeOrAbsolute));
+                Assert.IsTrue(Uri.IsWellFormedUriString(decodedLocation, UriKind.RelativeOrAbsolute));
+            }
         }
 
         [Then("the response should not contain the '(.*)' header")]

--- a/Solutions/Menes.PetStore/Menes/PetStore/PetStore.yaml
+++ b/Solutions/Menes.PetStore/Menes/PetStore/PetStore.yaml
@@ -189,6 +189,10 @@ paths:
             application/hal+json:
               schema:
                 $ref: "#/components/schemas/Pet"
+          headers:
+            ETag:
+              schema:
+                type: string
         '404':
           description: No pet with that ID
         default:

--- a/Solutions/Menes.PetStore/Menes/PetStore/PetStoreService.cs
+++ b/Solutions/Menes.PetStore/Menes/PetStore/PetStoreService.cs
@@ -342,9 +342,13 @@ namespace Menes.PetStore
 
             HalDocument response = await this.petMapper.MapAsync(result).ConfigureAwait(false);
 
-            return this
+            OpenApiResult openApiResponse = this
                 .OkResult(response, "application/hal+json")
                 .WithAuditData(("id", result.Id));
+
+            openApiResponse.Results.Add("ETag", $"\"{result.GetHashCode()}\"");
+
+            return openApiResponse;
         }
     }
 }

--- a/Solutions/Menes.Specs/Features/JsonTypeConversion/StringOutputParsing.feature
+++ b/Solutions/Menes.Specs/Features/JsonTypeConversion/StringOutputParsing.feature
@@ -1,0 +1,29 @@
+﻿@perScenarioContainer
+
+Feature: String Output Parsing
+    In order to implement a web API
+    As a developer
+    I want to be able to specify string values as or in response bodies within the OpenAPI specification and have corresponding response bodies deserialized and validated
+
+Scenario Outline: Body with valid values
+    Given I have constructed the OpenAPI specification with a response body of type 'string', and format ''
+    When I try to build a response body from the value '<Value>' of type 'System.String'
+    Then the response body should be '<ExpectedResult>'
+
+    Examples:
+        | Value     | ExpectedResult |
+        | Foo       | "Foo"          |
+        | /1234/abc | "/1234/abc"    |
+        |           | ""             |
+
+Scenario Outline: Header with valid values
+    Given I have constructed the OpenAPI specification with a response header called 'X-Test' of type 'string', and format ''
+    When I try to build a response with a header called 'X-Test' from the value '<Value>' of type 'System.String'
+    Then the response should container a header called 'X-Test' with value  '<ExpectedResult>'
+
+    Examples:
+        | Value     | ExpectedResult |
+        | Foo       | Foo            |
+        | /1234/abc | /1234/abc      |
+        |           |                |
+        | "Foo"     | "Foo"          |


### PR DESCRIPTION
Further to #329, we have encountered an additional case where the existing string conversion falls short. When passing a header value that contains special characters such as quotes - for example, when returning an ETag - the way the `StringConverter` processes the string means that we end up with invalid JSON. Then, when the new code introduced in #329 attempts to use `JToken.Parse` to remove the enclosing quotes, the method fails due to the incorrectly escaped characters.