### PR TITLE
Set IsPackable to false in Azure Functions projects

### DIFF
--- a/Solutions/Menes.PetStore.Hosting.AzureFunctions.InProcess/Menes.PetStore.Hosting.AzureFunctions.InProcess.csproj
+++ b/Solutions/Menes.PetStore.Hosting.AzureFunctions.InProcess/Menes.PetStore.Hosting.AzureFunctions.InProcess.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />

--- a/Solutions/Menes.PetStore.Hosting.AzureFunctions.Isolated/Menes.PetStore.Hosting.AzureFunctions.Isolated.csproj
+++ b/Solutions/Menes.PetStore.Hosting.AzureFunctions.Isolated/Menes.PetStore.Hosting.AzureFunctions.Isolated.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
Updated `Menes.PetStore.Hosting.AzureFunctions.InProcess.csproj` and `Menes.PetStore.Hosting.AzureFunctions.Isolated.csproj` to include the property `<IsPackable>false</IsPackable>`. This change indicates that the projects are not intended to be packed into NuGet packages, affecting their build and deployment.